### PR TITLE
Track In-App Show and Consume

### DIFF
--- a/src/authorization/authorization.ts
+++ b/src/authorization/authorization.ts
@@ -88,7 +88,7 @@ export function initIdentify(
           */
             if (
               !!(config?.url || '').match(
-                /(users\/update)|(events\/trackInApp)/gim
+                /(users\/update)|(events\/trackInApp)|(events\/inAppConsume)/gim
               )
             ) {
               return {
@@ -142,7 +142,7 @@ export function initIdentify(
           */
             if (
               !!(config?.url || '').match(
-                /(users\/update)|(events\/trackInApp)/gim
+                /(users\/update)|(events\/trackInApp)|(events\/inAppConsume)/gim
               )
             ) {
               return {


### PR DESCRIPTION
## JIRA Ticket(s) if any

* [MOB-3117](https://iterable.atlassian.net/browse/MOB-3117)

## Description

Hits POST `/events/trackInAppShow` and `/events/inAppConsume` when an in-app is shown to the user

I also know test coverage is looking a little worse for this `getInAppMessages` method now that this method keeps growing with each PR. I'm probably going to test the UI parts of it in it's own PR and decide how I want to abstract out pieces of it later. My gameplan with this is abstract as much as I can and test the methods individually and mock out the logic within the actual `getInAppMessages` method

## Test Steps

1. Send some messages to either yourself or the tester email in the sample app `iterable.tester@gmail.com`
2. Run sample app
3. Paint in-app messages
4. Ensure POST `/events/trackInAppShow` and `/events/inAppConsume` get hit when an in-app is shown
5. Ensure `/events/inAppConsume` does _*NOT*_ get hit if the in-app has `saveToInbox: true` in its payload.