### PR TITLE
Preload Images for iFrame Content

### DIFF
--- a/src/inapp/inapp.test.ts
+++ b/src/inapp/inapp.test.ts
@@ -418,19 +418,9 @@ describe('Utils', () => {
     });
 
     it('should paint an overlay', () => {
-      const mockFn = jest.fn();
-      const overlay = paintOverlay('#222', 0.8, mockFn);
+      const overlay = paintOverlay('#222', 0.8);
 
       expect(overlay.tagName).toBe('DIV');
-    });
-
-    it('should trigger onclick when overlay is clicked', () => {
-      const mockFn = jest.fn();
-      const overlay = paintOverlay('#222', 0.8, mockFn);
-
-      const clickEvent = new MouseEvent('click');
-      overlay.dispatchEvent(clickEvent);
-      expect(mockFn).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## JIRA Ticket(s) if any

* [MOB-3188](https://iterable.atlassian.net/browse/MOB-3188)

## Description

This PR does a couple things

1. Sets the height of the iFrame equal to the height of the content inside it
2. Preloads images before setting the height otherwise setting the height before the images are loaded, the iframe's height will be `contentHeight - heightOfImage`

## Test Steps

1. Start sample app
2. Clear cache
3. Start painting messages
    * by default there should be 2 messages, both with images in them
4. Look at chrome dev tools and ensure the images were loaded once before the iframe appeared and then another time from memory
5. Ensure iframe height is equal to the full height of the content

-------

1. Ensure dismissing iframe still works in all ways (esc key, clicking on overlay, clicking dismiss links)

-------

1. Ensure you don't ever see this issue where the iframe is too short:

![bad](https://user-images.githubusercontent.com/7387001/127036527-74f0a6e2-5f08-4098-8a5b-90e506634916.gif)

## Known Issues

If the user chooses by default to use the "disable cache" browser feature, the preloading method will be rendered useless, so this will definitely make all iframes appear too short, but IMO, this seems like an edge case. If we *want* to, we can add a a timeout to check the heights again and adjust as needed. I'll bring this up in the next product meeting

To test this just turn this setting on in chrome dev tools and then refresh and paint the messages:

<img width="413" alt="Screen Shot 2021-07-26 at 1 59 55 PM" src="https://user-images.githubusercontent.com/7387001/127036427-62ef8748-f778-4f3b-b0f1-ddca9657ed0f.png">
