### PR TITLE
Adds Timeout Before Displaying In-Apps

### DIFF
--- a/src/inapp/utils.ts
+++ b/src/inapp/utils.ts
@@ -56,42 +56,14 @@ export const paintIFrame = (
   srMessage?: string
 ) => {
   const iframe = document.createElement('iframe');
-  iframe.style.cssText = `
-    position: fixed;
-    border: none;
-    margin: auto;
-    width: 50%;
-    left: 0;
-    right: 0;
-    top: 0;
-    bottom: 0;
-    z-index: 9999;
-  `;
-
-  if (position === 'top-right') {
-    iframe.style.bottom = 'unset';
-    iframe.style.left = 'unset';
-    iframe.style.margin = 'unset';
-  }
-
-  if (position === 'bottom-right') {
-    iframe.style.top = 'unset';
-    iframe.style.left = 'unset';
-    iframe.style.margin = 'unset';
-  }
-
-  if (position === 'full') {
-    iframe.style.width = '100%';
-    iframe.style.height = '100%';
-  }
 
   /* 
-  find all the images in the in-app message, preload them, and 
-  only then set the height because we need to know how tall the images
-  are before we set the height of the iframe.
-  
-  This prevents a race condition where if we set the height before the images
-  are loaded, we might end up with a scrolling iframe
+    find all the images in the in-app message, preload them, and 
+    only then set the height because we need to know how tall the images
+    are before we set the height of the iframe.
+    
+    This prevents a race condition where if we set the height before the images
+    are loaded, we might end up with a scrolling iframe
   */
   const images =
     html?.match(/\b(https?:\/\/\S+(?:png|jpe?g|gif)\S*)\b/gim) || [];
@@ -107,7 +79,53 @@ export const paintIFrame = (
     iframe.contentWindow?.document?.close();
 
     callback(iframe);
-    iframe.height = iframe.contentWindow?.document.body.scrollHeight + 'px';
+
+    const timeout = setTimeout(() => {
+      /**
+        even though we preloaded the images before setting the height, we add an extra 100MS 
+        here to handle for the case where the user needs to download custom fonts. As 
+        of 07/27/2021, the preloading fonts API is still in a draft state
+
+        @see https://developer.mozilla.org/en-US/docs/Web/API/CSS_Font_Loading_API
+
+        but even if we did preload the fonts, it would still take a non-trivial amount
+        of computational time to apply the font to the text, so this setTimeout is acting more
+        as a failsafe just incase the new font causes the line-height to grow and create a
+        scrollbar in the iframe.
+      */
+      iframe.style.cssText = `
+        position: fixed;
+        border: none;
+        margin: auto;
+        width: 50%;
+        left: 0;
+        right: 0;
+        top: 0;
+        bottom: 0;
+        z-index: 9999;
+    `;
+
+      if (position === 'top-right') {
+        iframe.style.bottom = 'unset';
+        iframe.style.left = 'unset';
+        iframe.style.margin = 'unset';
+      }
+
+      if (position === 'bottom-right') {
+        iframe.style.top = 'unset';
+        iframe.style.left = 'unset';
+        iframe.style.margin = 'unset';
+      }
+
+      if (position === 'full') {
+        iframe.style.width = '100%';
+        iframe.style.height = '100%';
+      }
+
+      iframe.height = iframe.contentWindow?.document.body.scrollHeight + 'px';
+
+      clearTimeout(timeout);
+    }, 100);
   });
   if (srMessage) {
     srSpeak(srMessage, 'assertive');


### PR DESCRIPTION
## JIRA Ticket(s) if any

* [MOB-3194](https://iterable.atlassian.net/browse/MOB-3194)

## Description

Adds small timeout before showing in-apps to account for any slowly applied CSS (AKA downloaded fonts)

## Test Steps

1. Load app
2. See 4th in-app message (which should be the "cha-ching dosh" message)
3. See no scrollbar or layout jumpiness after the iframe appears