### PR TITLE
Add Method for /track Endpoint

### DIFF
--- a/src/events/events.test.ts
+++ b/src/events/events.test.ts
@@ -1,6 +1,7 @@
 import MockAdapter from 'axios-mock-adapter';
 import { baseAxiosRequest } from '../request';
 import {
+  track,
   trackInAppClick,
   trackInAppClose,
   trackInAppConsume,
@@ -11,6 +12,16 @@ import {
 const mockRequest = new MockAdapter(baseAxiosRequest);
 
 describe('Events Requests', () => {
+  it('return the correct payload for trackInAppClick', async () => {
+    mockRequest.onPost('/events/track').reply(200, {
+      msg: 'hello'
+    });
+
+    const response = await track({ eventName: 'test' });
+
+    expect(JSON.parse(response.config.data).eventName).toBe('test');
+    expect(response.data.msg).toBe('hello');
+  });
   it('return the correct payload for trackInAppClick', async () => {
     mockRequest.onPost('/events/trackInAppClick').reply(200, {
       msg: 'hello'

--- a/src/events/events.ts
+++ b/src/events/events.ts
@@ -1,6 +1,14 @@
 import { baseIterableRequest } from '../request';
-import { InAppEventRequestParams } from './types';
+import { InAppEventRequestParams, InAppTrackRequestParams } from './types';
 import { IterableResponse } from '../types';
+
+export const track = (payload: InAppTrackRequestParams) => {
+  return baseIterableRequest<IterableResponse>({
+    method: 'POST',
+    url: '/events/track',
+    data: payload
+  });
+};
 
 export const trackInAppClose = (payload: InAppEventRequestParams) => {
   return baseIterableRequest<IterableResponse>({

--- a/src/events/types.ts
+++ b/src/events/types.ts
@@ -1,8 +1,15 @@
 import { IterablePlatform } from '../types';
 
+export interface InAppTrackRequestParams {
+  eventName: string;
+  id?: string;
+  createdAt?: number;
+  dataFields?: Record<string, any>;
+  campaignId?: number;
+  templateId?: number;
+}
+
 export interface InAppEventRequestParams {
-  // email?: string;
-  // userId: string;
   messageId: string;
   clickedUrl?: string;
   messageContext?: {


### PR DESCRIPTION
## JIRA Ticket(s) if any

* [MOB-3131](https://iterable.atlassian.net/browse/MOB-3131)

## Description

Exposes method for POST `/events/track` and test

## Test Steps

1. In the sample app, import and call the `track` method like so in `example/src/index.ts`:

```ts
import { initIdentify, track} from 'iterable-web-sdk';

((): void => {
  /* set token in the SDK */
  const { setEmail } = initIdentify(process.env.API_KEY || '');
  setEmail('iterable.tester@gmail.com');

  track({ eventName: 'something' })
})()
```

2. Ensure app calls POST `/events/track` with the payload you provided in the code.