### PR TITLE
Create User Upon setUserID

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,2 +1,5 @@
 /* number of MS to wait between in-app messages to show the next one */
 export const DISPLAY_INTERVAL_DEFAULT = 30000;
+
+/* how many times we try to create a new user when _setUserID_ is invoked */
+export const RETRY_USER_ATTEMPTS = 0;


### PR DESCRIPTION
## JIRA Ticket(s) if any

* [MOB-3218](https://iterable.atlassian.net/browse/MOB-3218)

## Description

Calls `updateUser` when setting a user ID for the case where the user does not exist yet in the Iterable instance, which would cause any tracking calls to fail

## Test Steps

1. Start app `yarn install:all && yarn start:all`
2. Open `example/src/index.ts`
3. Run this code

```ts
import './styles/index.css';
import { initIdentify } from 'iterable-web-sdk';

((): void => {
  const { setUserID } = initIdentify(process.env.API_KEY || '');

  setUserID('fdsafdsaf423423');
})()
```

4. Ensure 1 POST `/users/update` call is made with the passed user ID and `{ preferUserID: true }`