### PR TITLE
Handle UpdateEmail Calls

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -12,10 +12,23 @@
   <div id="root">
     <h1 class="heading">In-App Messaging Controls</h1>
     <div class="control-wrapper">
-      <button id="start">Start Auto-Painting In-App Messages</button>
+      <button id="login">Login</button>
+      <button id="start" class="disabled" aria-disabled>Login to See In-App Messages</button>
       <button id="pause">Pause Message Stream</button>
       <button id="resume">Resume Message Stream</button>
       <button id="logout">Logout</button>
+      <form id="change-email-form">
+        <div class="input-wrapper">
+          <label for="change-email">Update Email</label>
+          <input 
+            placeholder="Enter new email" 
+            type="text" 
+            name="change-email" 
+            id="change-email-input" 
+          />
+        </div>
+        <button type="submit" id="change-email-btn" class="disabled" aria-disabled>Change email</button>
+      </form>
     </div>
   </div>
   <footer>hi im the footer</footer>

--- a/example/src/index.ts
+++ b/example/src/index.ts
@@ -1,12 +1,16 @@
 import './styles/index.css';
 import axios from 'axios';
-import { initIdentify, getInAppMessages } from '@iterable/web-sdk';
+import {
+  initIdentify,
+  getInAppMessages,
+  updateUserEmail
+} from '@iterable/web-sdk';
 
 ((): void => {
   /* set token in the SDK */
   const { setEmail, logout } = initIdentify(
     process.env.API_KEY || '',
-    (email) => {
+    ({ email }) => {
       return axios
         .post(
           'http://localhost:5000/generate',
@@ -38,6 +42,97 @@ import { initIdentify, getInAppMessages } from '@iterable/web-sdk';
   );
 
   const startBtn = document.getElementById('start');
+  const loginBtn = document.getElementById('login');
+  const changeEmailForm = document.getElementById('change-email-form');
+  const changeEmailBtn = document.getElementById('change-email-btn');
+
+  const handleGetMessagesClick = (event: MouseEvent) => {
+    event.preventDefault();
+    if (startBtn.getAttribute('aria-disabled') !== 'true') {
+      startBtn.innerText = `Loading...`;
+      startBtn.setAttribute('aria-disabled', 'true');
+      startBtn.className = 'disabled';
+      request()
+        .then((response) => {
+          startBtn.innerText = `${response.data.inAppMessages.length} total messages retrieved!`;
+        })
+        .catch(console.warn);
+    }
+  };
+
+  const handleLoginClick = (event: MouseEvent) => {
+    const email =
+      localStorage.getItem('iterable-email') || 'iterable.tester@gmail.com';
+
+    /* disable login btn */
+    if (loginBtn.getAttribute('aria-disabled') !== 'true') {
+      event.preventDefault();
+      /* login */
+      loginBtn.setAttribute('aria-disabled', 'true');
+      loginBtn.className = 'disabled';
+      loginBtn.innerText = `Loading...`;
+      setEmail(email).then(() => {
+        /* enable change email button */
+        changeEmailBtn.classList.remove('disabled');
+        changeEmailBtn.setAttribute('aria-disabled', 'false');
+
+        changeEmailBtn.innerText = 'Change email';
+
+        /* enable in-app message button */
+        loginBtn.innerText = `Logged in as ${email}`;
+        startBtn.setAttribute('aria-disabled', 'false');
+        startBtn.classList.remove('disabled');
+        startBtn.innerText = 'Start painting in-app messages';
+        /* aria-disabled doesn't actually disable the button lol */
+
+        startBtn.addEventListener('click', handleGetMessagesClick);
+      });
+    }
+  };
+
+  const handleChangeEmail = (event: MouseEvent) => {
+    event.preventDefault();
+    const inputField = document.getElementById(
+      'change-email-input'
+    ) as HTMLInputElement;
+    const newEmail = inputField.value;
+
+    changeEmailBtn.setAttribute('aria-disabled', 'true');
+    changeEmailBtn.className = 'disabled';
+    changeEmailBtn.innerText = `Loading...`;
+
+    startBtn.setAttribute('aria-disabled', 'true');
+    startBtn.className = 'disabled';
+    startBtn.removeEventListener('click', handleGetMessagesClick);
+
+    updateUserEmail(newEmail)
+      .then(() => {
+        localStorage.setItem('iterable-email', newEmail);
+        loginBtn.innerText = `Logged in as ${newEmail}`;
+
+        changeEmailBtn.setAttribute('aria-disabled', 'false');
+        changeEmailBtn.classList.remove('disabled');
+        changeEmailBtn.innerText = 'Change email';
+        inputField.value = '';
+
+        startBtn.setAttribute('aria-disabled', 'false');
+        startBtn.classList.remove('disabled');
+
+        startBtn.addEventListener('click', handleGetMessagesClick);
+      })
+      .catch(() => {
+        inputField.value = 'Something went wrong.';
+        changeEmailBtn.setAttribute('aria-disabled', 'false');
+        changeEmailBtn.classList.remove('disabled');
+        changeEmailBtn.innerText = 'Change email';
+
+        startBtn.setAttribute('aria-disabled', 'false');
+        startBtn.classList.remove('disabled');
+      });
+  };
+
+  loginBtn.addEventListener('click', handleLoginClick);
+  changeEmailForm.addEventListener('submit', handleChangeEmail);
 
   document
     .getElementById('pause')
@@ -50,25 +145,17 @@ import { initIdentify, getInAppMessages } from '@iterable/web-sdk';
     .addEventListener('click', pauseMessageStream);
   document.getElementById('logout').addEventListener('click', () => {
     logout();
-    startBtn.innerText = 'Start Auto-Painting In-App Messages';
-    startBtn.setAttribute('aria-disabled', 'false');
-    startBtn.className = '';
-  });
-
-  startBtn.addEventListener('click', (event) => {
-    event.preventDefault();
-    if (startBtn.getAttribute('aria-disabled') !== 'true') {
-      startBtn.innerText = `Loading...`;
-      setEmail('iterable.tester@gmail.com').then(() => {
-        /* aria-disabled doesn't actually disable the button lol */
-        request()
-          .then((response) => {
-            startBtn.innerText = `${response.data.inAppMessages.length} total messages retrieved!`;
-          })
-          .catch(console.warn);
-      });
-    }
+    startBtn.innerText = 'Login to See In-App Messages';
     startBtn.setAttribute('aria-disabled', 'true');
     startBtn.className = 'disabled';
+
+    loginBtn.classList.remove('disabled');
+    loginBtn.setAttribute('aria-disabled', 'false');
+    loginBtn.innerText = 'Login';
+
+    changeEmailBtn.setAttribute('aria-disabled', 'true');
+    changeEmailBtn.className = 'disabled';
+
+    startBtn.removeEventListener('click', handleGetMessagesClick);
   });
 })();

--- a/example/src/styles/index.css
+++ b/example/src/styles/index.css
@@ -14,6 +14,55 @@ html, body {
   justify-content: space-evenly;
 }
 
+#change-email-form {
+  width: 60%;
+  display: flex;
+  flex-flow: row;
+  justify-content: center;
+}
+
+.input-wrapper {
+  flex-grow: 1;
+  display: flex;
+  flex-flow: column;
+  margin-right: 2em;
+  transform: translateY(3.5px);
+}
+
+#change-email-form button {
+  width: 30%;
+  margin: 0;
+}
+
+#change-email-form input {
+  margin-top: .5em;
+  flex-grow: 1;
+  padding: 1em;
+}
+
+@media screen and (max-width: 800px) {
+  #change-email-form {
+    width: 60%;
+    display: flex;
+    flex-flow: column;
+    justify-content: center;
+  }
+  
+  .input-wrapper {
+    margin-right: 0;
+    transform: translateY(0);
+  }
+  
+  #change-email-form button {
+    width: 100%;
+    margin-top: 1em;
+  }
+  
+  #change-email-form input {
+    height: 50px;
+  }
+}
+
 button.disabled {
   background-color: gray;
   color: #c7c7c7;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,4 +4,5 @@ export const DISPLAY_INTERVAL_DEFAULT = 30000;
 /* how many times we try to create a new user when _setUserID_ is invoked */
 export const RETRY_USER_ATTEMPTS = 0;
 
+/* code that comes back on 401 responses from Iterable API */
 export const INVALID_JWT_CODE = 'InvalidJwtPayload';

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,7 +20,8 @@ export type IterableErrorStatus =
   | 'InvalidEmailAddressError'
   | 'DatabaseError'
   | 'EmailAlreadyExists'
-  | 'Forbidden';
+  | 'Forbidden'
+  | 'InvalidJwtPayload';
 
 export type IterablePlatform = 'iOS' | 'Android';
 


### PR DESCRIPTION
## JIRA Ticket(s) if any

* [MOB-3372](https://iterable.atlassian.net/browse/MOB-3372)

## Description

When POST `users/updateEmail` is called, we need to regenerate the user's JWT because it needs to be encoded with the new email, otherwise requests after the email is updated are going to fail.

The flow basically goes like this:

1. User logs in and a JWT is generated
2. User updates their email through the API
3. We wait for that request to finish, call their JWT generation async method, then add the new email to all outgoing requests and set the new JWT as an auth header on those requests as well

## Test Steps

1. As expected run through the [JWT test steps from this PR](https://github.com/Iterable/iterable-web-sdk/pull/38) to generate a JWT token
2. Run the sample app
3. Click "login"
4. Enter in a new email address and click "change email"
5. (assuming that request 200s), wait a minute to see the JWT request regenerated with the new email address you entered
6. Then click "start painting in-app messages" to request in-app messages
7. See that GET request made with the new email address you entered and the new JWT that was generated