### PR TITLE
Add Configuration Settings and Log Level

### DIFF
--- a/src/authorization/authorization.test.ts
+++ b/src/authorization/authorization.test.ts
@@ -140,7 +140,6 @@ describe('API Key Interceptors', () => {
     it('should not request a new JWT if the first request failed', async () => {
       /* 5 minutes before the JWT expires */
       Date.now = jest.fn(() => 1630617433001);
-      const spy = jest.spyOn(console, 'warn').mockImplementation();
       /* this JWT expires in 5 minutes */
       const mockGenerateJWT = jest
         .fn()
@@ -153,10 +152,6 @@ describe('API Key Interceptors', () => {
         expect(mockGenerateJWT).toHaveBeenCalledTimes(1);
         jest.advanceTimersByTime(60000 * 4.1);
         expect(mockGenerateJWT).toHaveBeenCalledTimes(1);
-        expect(spy).toHaveBeenCalledWith(
-          'Could not generate JWT. Please try calling setEmail again.'
-        );
-        spy.mockRestore();
       }
     });
 
@@ -873,7 +868,6 @@ describe('User Identification', () => {
 
       it('should try /users/update 0 times if request to create a user fails', async () => {
         mockRequest.onPost('/users/update').reply(400, {});
-        const spy = jest.spyOn(console, 'warn').mockImplementation();
 
         const { setUserID } = initIdentify('123', () =>
           Promise.resolve(MOCK_JWT_KEY)
@@ -886,7 +880,6 @@ describe('User Identification', () => {
               (e: any) => !!e.url?.match(/users\/update/gim)
             ).length
           ).toBe(1);
-          spy.mockRestore();
         }
       });
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,3 +4,4 @@ export * from './inapp';
 export * from './request';
 export * from './events';
 export * from './commerce';
+export { config } from './utils/config';

--- a/src/utils/config.test.ts
+++ b/src/utils/config.test.ts
@@ -1,0 +1,12 @@
+import { config } from './config';
+
+describe('Config', () => {
+  it('should get config', () => {
+    expect(config.getConfig('logLevel')).toBe('none');
+  });
+
+  it('should set config', () => {
+    config.setConfig({ logLevel: 'verbose' });
+    expect(config.getConfig('logLevel')).toBe('verbose');
+  });
+});

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,0 +1,23 @@
+interface Options {
+  logLevel: 'none' | 'verbose';
+}
+
+const _config = () => {
+  let options: Options = {
+    logLevel: 'none'
+  };
+
+  return {
+    getConfig: (option: keyof Options) => options[option],
+    setConfig: (newOptions: Partial<Options>) => {
+      options = {
+        ...options,
+        ...newOptions
+      };
+    }
+  };
+};
+
+export const config = _config();
+
+export default config;


### PR DESCRIPTION
## JIRA Ticket(s) if any

* [MOB-3373](https://iterable.atlassian.net/browse/MOB-3373)

## Description

Creates a configuration closure function to set and get config settings (with the only one being `logLevel` right now.

Wraps `console.warn` inside of `logLevel` conditions.

Right now, there isn't any really important logs, but this may get fleshed out in the future.

## Test Steps

1. Open `example/src/index.ts`
2. Add `import { config } from '@iterable/web-sdk'`
3. Call `config.setConfig({ logLevel: 'verbose' })` before the authorization call
4. Make the auth call fail somehow (i.e. just change the endpoint to a bogus string)
5. See extra console logging in the browser