### PR TITLE
(Part 1) /commerce Client-Side Validation

### DIFF
--- a/src/commerce/commerce.schema.ts
+++ b/src/commerce/commerce.schema.ts
@@ -1,0 +1,36 @@
+import { array, boolean, number, object, string } from 'yup';
+
+const userShape = object().shape({
+  dataFields: object(),
+  preferUserId: boolean(),
+  mergeNestedObjects: boolean()
+});
+
+const itemShape = object().shape({
+  id: string().required(),
+  sku: string(),
+  name: string().required(),
+  description: string(),
+  categories: array(string()),
+  price: number().required(),
+  quantity: number().required(),
+  imageUrl: string(),
+  url: string(),
+  dataFields: object()
+});
+
+export const updateCartSchema = object().shape({
+  user: userShape,
+  items: array(itemShape).required()
+});
+
+export const trackPurchaseSchema = object().shape({
+  id: string(),
+  user: userShape,
+  items: array(itemShape).required(),
+  campaignId: string(),
+  templateId: string(),
+  total: number().required(),
+  createdAt: number(),
+  dataFields: object()
+});

--- a/src/commerce/commerce.test.ts
+++ b/src/commerce/commerce.test.ts
@@ -1,6 +1,7 @@
 import MockAdapter from 'axios-mock-adapter';
 import { baseAxiosRequest } from '../request';
 import { trackPurchase, updateCart } from './commerce';
+import { createClientError } from '../utils/testUtils';
 
 const mockRequest = new MockAdapter(baseAxiosRequest);
 
@@ -11,12 +12,55 @@ describe('Users Requests', () => {
     });
 
     const response = await updateCart({
-      items: []
+      items: [
+        {
+          id: 'fdsafds',
+          name: 'banana',
+          quantity: 2,
+          price: 12
+        }
+      ]
     });
 
-    expect(JSON.parse(response.config.data).items).toEqual([]);
+    expect(JSON.parse(response.config.data).items).toEqual([
+      {
+        id: 'fdsafds',
+        name: 'banana',
+        quantity: 2,
+        price: 12
+      }
+    ]);
     expect(JSON.parse(response.config.data).user.preferUserId).toBe(true);
     expect(response.data.msg).toBe('hello');
+  });
+
+  it('should reject updateCart on bad params', async () => {
+    try {
+      await updateCart({
+        items: [{} as any]
+      });
+    } catch (e) {
+      expect(e).toEqual(
+        createClientError([
+          {
+            error: 'items[0].id is a required field',
+            field: 'items[0].id'
+          },
+          {
+            error: 'items[0].name is a required field',
+            field: 'items[0].name'
+          },
+          {
+            error: 'items[0].price is a required field',
+            field: 'items[0].price'
+          },
+          {
+            error: 'items[0].quantity is a required field',
+            field: 'items[0].quantity'
+          }
+        ])
+      );
+    }
   });
 
   it('should set params and return the correct payload for trackPurchase', async () => {
@@ -24,7 +68,10 @@ describe('Users Requests', () => {
       msg: 'hello'
     });
 
-    const response = await trackPurchase({ items: [], total: 100 });
+    const response = await trackPurchase({
+      items: [],
+      total: 100
+    });
 
     expect(JSON.parse(response.config.data).total).toBe(100);
     expect(JSON.parse(response.config.data).items).toEqual([]);
@@ -44,18 +91,54 @@ describe('Users Requests', () => {
       user: {
         email: 'hello@gmail.com',
         userId: '1234'
-      }
+      },
+      items: []
     } as any);
     const trackResponse = await trackPurchase({
       user: {
         email: 'hello@gmail.com',
         userId: '1234'
-      }
+      },
+      items: [],
+      total: 100
     } as any);
 
     expect(JSON.parse(updateResponse.config.data).user.email).toBeUndefined();
     expect(JSON.parse(updateResponse.config.data).user.userId).toBeUndefined();
     expect(JSON.parse(trackResponse.config.data).user.email).toBeUndefined();
     expect(JSON.parse(trackResponse.config.data).user.userId).toBeUndefined();
+  });
+
+  it('should reject updateCart on bad params', async () => {
+    try {
+      await trackPurchase({
+        items: [{} as any]
+      } as any);
+    } catch (e) {
+      expect(e).toEqual(
+        createClientError([
+          {
+            error: 'items[0].id is a required field',
+            field: 'items[0].id'
+          },
+          {
+            error: 'items[0].name is a required field',
+            field: 'items[0].name'
+          },
+          {
+            error: 'items[0].price is a required field',
+            field: 'items[0].price'
+          },
+          {
+            error: 'items[0].quantity is a required field',
+            field: 'items[0].quantity'
+          },
+          {
+            error: 'total is a required field',
+            field: 'total'
+          }
+        ])
+      );
+    }
   });
 });

--- a/src/commerce/commerce.ts
+++ b/src/commerce/commerce.ts
@@ -1,6 +1,7 @@
 import { baseIterableRequest } from '../request';
 import { TrackPurchaseRequestParams, UpdateCartRequestParams } from './types';
 import { IterableResponse } from '../types';
+import { updateCartSchema, trackPurchaseSchema } from './commerce.schema';
 
 export const updateCart = (payload: UpdateCartRequestParams) => {
   /* a customer could potentially send these up if they're not using TypeScript */
@@ -18,6 +19,9 @@ export const updateCart = (payload: UpdateCartRequestParams) => {
         ...payload.user,
         preferUserId: true
       }
+    },
+    validation: {
+      data: updateCartSchema
     }
   });
 };
@@ -38,6 +42,9 @@ export const trackPurchase = (payload: TrackPurchaseRequestParams) => {
         ...payload.user,
         preferUserId: true
       }
+    },
+    validation: {
+      data: trackPurchaseSchema
     }
   });
 };

--- a/src/inapp/tests/inapp.test.ts
+++ b/src/inapp/tests/inapp.test.ts
@@ -7,6 +7,7 @@ import { messages } from '../../__data__/inAppMessages';
 import { getInAppMessages } from '../inapp';
 import { initIdentify } from '../../authorization';
 import { WEB_PLATFORM } from '../../constants';
+import { createClientError } from '../../utils/testUtils';
 
 jest.mock('../../utils/srSpeak', () => ({
   srSpeak: jest.fn()
@@ -40,37 +41,20 @@ describe('getInAppMessages', () => {
 
     it('should reject if fails client-side validation', async () => {
       try {
-        await getInAppMessages({
-          count: 10
-        } as any);
+        await getInAppMessages({} as any);
       } catch (e) {
-        expect(e.response.data).toEqual({
-          code: 'GenericError',
-          msg: 'Client-side error',
-          clientErrors: [
+        expect(e).toEqual(
+          createClientError([
+            {
+              error: 'count is a required field',
+              field: 'count'
+            },
             {
               error: 'packageName is a required field',
               field: 'packageName'
             }
-          ]
-        });
-      }
-
-      try {
-        await getInAppMessages({
-          packageName: 'my-lil-website'
-        } as any);
-      } catch (e) {
-        expect(e.response.data).toEqual({
-          code: 'GenericError',
-          msg: 'Client-side error',
-          clientErrors: [
-            {
-              error: 'count is a required field',
-              field: 'count'
-            }
-          ]
-        });
+          ])
+        );
       }
     });
 
@@ -136,43 +120,20 @@ describe('getInAppMessages', () => {
 
     it('should reject if fails client-side validation', async () => {
       try {
-        await getInAppMessages(
-          {
-            count: 10
-          } as any,
-          true
-        ).request();
+        await getInAppMessages({} as any, true).request();
       } catch (e) {
-        expect(e.response.data).toEqual({
-          code: 'GenericError',
-          msg: 'Client-side error',
-          clientErrors: [
+        expect(e).toEqual(
+          createClientError([
+            {
+              error: 'count is a required field',
+              field: 'count'
+            },
             {
               error: 'packageName is a required field',
               field: 'packageName'
             }
-          ]
-        });
-      }
-
-      try {
-        await getInAppMessages(
-          {
-            packageName: 'my-lil-website'
-          } as any,
-          true
-        ).request();
-      } catch (e) {
-        expect(e.response.data).toEqual({
-          code: 'GenericError',
-          msg: 'Client-side error',
-          clientErrors: [
-            {
-              error: 'count is a required field',
-              field: 'count'
-            }
-          ]
-        });
+          ])
+        );
       }
     });
 

--- a/src/utils/testUtils.ts
+++ b/src/utils/testUtils.ts
@@ -1,0 +1,15 @@
+export const createClientError = (
+  clientErrors: { error: string; field?: string }[]
+) => ({
+  response: {
+    data: {
+      code: 'GenericError',
+      msg: 'Client-side error',
+      clientErrors
+    },
+    status: 400,
+    statusText: '',
+    headers: {},
+    config: {}
+  }
+});


### PR DESCRIPTION
## JIRA Ticket(s) if any

* [MOB-3104](https://iterable.atlassian.net/browse/MOB-3104)

## Description

Adds client-side validation for /commerce endpoints

## Test Steps

1. Run `yarn test`
2. Ensure tests pass

-----

Alternatively:

1. Make a `trackPurchase` or `updateCart` call
2. Omit some required field
3. See a promise rejection with the reason why in the payload. Example:

```ts
import { updateCart } from '@iterable/web-sdk'

updateCart([ { } ])
```