### PR TITLE
(Part 2) Users Client-Side Validation

### DIFF
--- a/src/users/users.schema.ts
+++ b/src/users/users.schema.ts
@@ -1,0 +1,16 @@
+import { array, boolean, number, object } from 'yup';
+
+export const updateUserSchema = object().shape({
+  dataFields: object(),
+  preferUserId: boolean(),
+  mergeNestedObjects: boolean()
+});
+
+export const updateSubscriptionsSchema = object().shape({
+  emailListIds: array(number()),
+  unsubscribedChannelIds: array(number()),
+  unsubscribedMessageTypeIds: array(number()),
+  subscribedMessageTypeIds: array(number()),
+  campaignId: number(),
+  templateId: number()
+});

--- a/src/users/users.test.ts
+++ b/src/users/users.test.ts
@@ -1,6 +1,7 @@
 import MockAdapter from 'axios-mock-adapter';
 import { baseAxiosRequest } from '../request';
 import { updateSubscriptions, updateUser, updateUserEmail } from './users';
+import { createClientError } from '../utils/testUtils';
 
 const mockRequest = new MockAdapter(baseAxiosRequest);
 
@@ -19,6 +20,32 @@ describe('Users Requests', () => {
     expect(response.data.msg).toBe('hello');
   });
 
+  it('should reject updateUser on bad params', async () => {
+    try {
+      await updateUser({
+        dataFields: 'string',
+        preferUserId: 'string',
+        mergeNestedObjects: 'string'
+      } as any);
+    } catch (e) {
+      expect(e).toEqual(
+        createClientError([
+          {
+            error:
+              'dataFields must be a `object` type, but the final value was: `null` (cast from the value `"string"`).\n' +
+              ' If "null" is intended as an empty value be sure to mark the schema as `.nullable()`',
+            field: 'dataFields'
+          },
+          {
+            error:
+              'mergeNestedObjects must be a `boolean` type, but the final value was: `"string"`.',
+            field: 'mergeNestedObjects'
+          }
+        ])
+      );
+    }
+  });
+
   it('should set params and return the correct payload for updateUserEmail', async () => {
     mockRequest.onPost('/users/updateEmail').reply(200, {
       msg: 'hello'
@@ -28,6 +55,23 @@ describe('Users Requests', () => {
 
     expect(JSON.parse(response.config.data).newEmail).toBe('hello@gmail.com');
     expect(response.data.msg).toBe('hello');
+  });
+
+  it('should reject updateUserEmail on bad params', async () => {
+    try {
+      await updateUserEmail(null as any);
+    } catch (e) {
+      expect(e).toEqual(
+        createClientError([
+          {
+            error:
+              'newEmail must be a `string` type, but the final value was: `null`.\n' +
+              ' If "null" is intended as an empty value be sure to mark the schema as `.nullable()`',
+            field: 'newEmail'
+          }
+        ])
+      );
+    }
   });
 
   it('should set params and return the correct payload for updateSubscriptions', async () => {
@@ -57,6 +101,58 @@ describe('Users Requests', () => {
     expect(JSON.parse(response.config.data).campaignId).toBe(5);
     expect(JSON.parse(response.config.data).templateId).toBe(556);
     expect(response.data.msg).toBe('hello');
+  });
+
+  it('should reject updateSubscriptions on bad params', async () => {
+    try {
+      await updateSubscriptions({
+        emailListIds: 'string',
+        unsubscribedChannelIds: 'string',
+        unsubscribedMessageTypeIds: 'string',
+        subscribedMessageTypeIds: 'string',
+        campaignId: 'string',
+        templateId: 'string'
+      } as any);
+    } catch (e) {
+      expect(e).toEqual(
+        createClientError([
+          {
+            error:
+              'emailListIds must be a `array` type, but the final value was: `null` (cast from the value `"string"`).\n' +
+              ' If "null" is intended as an empty value be sure to mark the schema as `.nullable()`',
+            field: 'emailListIds'
+          },
+          {
+            error:
+              'unsubscribedChannelIds must be a `array` type, but the final value was: `null` (cast from the value `"string"`).\n' +
+              ' If "null" is intended as an empty value be sure to mark the schema as `.nullable()`',
+            field: 'unsubscribedChannelIds'
+          },
+          {
+            error:
+              'unsubscribedMessageTypeIds must be a `array` type, but the final value was: `null` (cast from the value `"string"`).\n' +
+              ' If "null" is intended as an empty value be sure to mark the schema as `.nullable()`',
+            field: 'unsubscribedMessageTypeIds'
+          },
+          {
+            error:
+              'subscribedMessageTypeIds must be a `array` type, but the final value was: `null` (cast from the value `"string"`).\n' +
+              ' If "null" is intended as an empty value be sure to mark the schema as `.nullable()`',
+            field: 'subscribedMessageTypeIds'
+          },
+          {
+            error:
+              'campaignId must be a `number` type, but the final value was: `NaN` (cast from the value `"string"`).',
+            field: 'campaignId'
+          },
+          {
+            error:
+              'templateId must be a `number` type, but the final value was: `NaN` (cast from the value `"string"`).',
+            field: 'templateId'
+          }
+        ])
+      );
+    }
   });
 
   it('should not allow a passed userId or email for API methods', async () => {

--- a/src/users/users.ts
+++ b/src/users/users.ts
@@ -1,6 +1,8 @@
+import { object, string } from 'yup';
 import { IterableResponse } from '../types';
 import { baseIterableRequest } from '../request';
 import { UpdateSubscriptionParams, UpdateUserParams } from './types';
+import { updateSubscriptionsSchema, updateUserSchema } from './users.schema';
 
 export const updateUserEmail = (newEmail: string) => {
   return baseIterableRequest<IterableResponse>({
@@ -8,6 +10,11 @@ export const updateUserEmail = (newEmail: string) => {
     url: '/users/updateEmail',
     data: {
       newEmail
+    },
+    validation: {
+      data: object().shape({
+        newEmail: string().required()
+      })
     }
   });
 };
@@ -23,6 +30,9 @@ export const updateUser = (payload: UpdateUserParams = {}) => {
     data: {
       ...payload,
       preferUserId: true
+    },
+    validation: {
+      data: updateUserSchema
     }
   });
 };
@@ -37,6 +47,9 @@ export const updateSubscriptions = (
   return baseIterableRequest<IterableResponse>({
     method: 'POST',
     url: '/users/updateSubscriptions',
-    data: payload
+    data: payload,
+    validation: {
+      data: updateSubscriptionsSchema
+    }
   });
 };


### PR DESCRIPTION
## JIRA Ticket(s) if any

* [MOB-3104](https://iterable.atlassian.net/browse/MOB-3104)

## Description

Adds client-side validation for /users endpoints

## Test Steps

1. Run `yarn test`
2. Ensure tests pass

-----

Alternatively:

1. Make a `updateUser` or `updateUserEmail` or `updateSubscruptions` call
2. Omit some required field
3. See a promise rejection with the reason why in the payload. Example:

```ts
import { updateUserEmail } from '@iterable/web-sdk'

updateUserEmail()
```