### PR TITLE
(Part 3) /events Client-Side Validation

### DIFF
--- a/src/events/events.schema.ts
+++ b/src/events/events.schema.ts
@@ -1,0 +1,30 @@
+import { boolean, number, object, string } from 'yup';
+
+export const trackSchema = object().shape({
+  eventName: string().required(),
+  id: string(),
+  createdAt: number(),
+  dataFields: object(),
+  campaignId: number(),
+  templateId: number()
+});
+
+export const eventRequestSchema = object().shape({
+  messageId: string().required(),
+  clickedUrl: string(),
+  messageContext: object().shape({
+    saveToInbox: boolean(),
+    silentInbox: boolean(),
+    location: string()
+  }),
+  closeAction: string(),
+  deviceInfo: object()
+    .shape({
+      deviceId: string().required(),
+      platform: string().required(),
+      appPackageName: string().required()
+    })
+    .required(),
+  inboxSessionId: string(),
+  createdAt: number()
+});

--- a/src/events/events.test.ts
+++ b/src/events/events.test.ts
@@ -9,6 +9,7 @@ import {
   trackInAppOpen
 } from './events';
 import { WEB_PLATFORM } from '../constants';
+import { createClientError } from '../utils/testUtils';
 
 const mockRequest = new MockAdapter(baseAxiosRequest);
 
@@ -34,11 +35,26 @@ describe('Events Requests', () => {
     });
   });
 
-  it('return the correct payload for trackInAppClick', async () => {
+  it('return the correct payload for track', async () => {
     const response = await track({ eventName: 'test' });
 
     expect(JSON.parse(response.config.data).eventName).toBe('test');
     expect(response.data.msg).toBe('hello');
+  });
+
+  it('should reject track on bad params', async () => {
+    try {
+      await track({} as any);
+    } catch (e) {
+      expect(e).toEqual(
+        createClientError([
+          {
+            error: 'eventName is a required field',
+            field: 'eventName'
+          }
+        ])
+      );
+    }
   });
 
   it('return the correct payload for trackInAppClick', async () => {
@@ -57,6 +73,25 @@ describe('Events Requests', () => {
     expect(response.data.msg).toBe('hello');
   });
 
+  it('should reject trackInAppClick on bad params', async () => {
+    try {
+      await trackInAppClick({} as any);
+    } catch (e) {
+      expect(e).toEqual(
+        createClientError([
+          {
+            error: 'messageId is a required field',
+            field: 'messageId'
+          },
+          {
+            error: 'deviceInfo.appPackageName is a required field',
+            field: 'deviceInfo.appPackageName'
+          }
+        ])
+      );
+    }
+  });
+
   it('return the correct payload for trackInAppClose', async () => {
     const response = await trackInAppClose({
       messageId: '123',
@@ -71,6 +106,25 @@ describe('Events Requests', () => {
       WEB_PLATFORM
     );
     expect(response.data.msg).toBe('hello');
+  });
+
+  it('should reject trackInAppClose on bad params', async () => {
+    try {
+      await trackInAppClose({} as any);
+    } catch (e) {
+      expect(e).toEqual(
+        createClientError([
+          {
+            error: 'messageId is a required field',
+            field: 'messageId'
+          },
+          {
+            error: 'deviceInfo.appPackageName is a required field',
+            field: 'deviceInfo.appPackageName'
+          }
+        ])
+      );
+    }
   });
 
   it('return the correct payload for trackInAppConsume', async () => {
@@ -89,6 +143,25 @@ describe('Events Requests', () => {
     expect(response.data.msg).toBe('hello');
   });
 
+  it('should reject trackInAppConsume on bad params', async () => {
+    try {
+      await trackInAppConsume({} as any);
+    } catch (e) {
+      expect(e).toEqual(
+        createClientError([
+          {
+            error: 'messageId is a required field',
+            field: 'messageId'
+          },
+          {
+            error: 'deviceInfo.appPackageName is a required field',
+            field: 'deviceInfo.appPackageName'
+          }
+        ])
+      );
+    }
+  });
+
   it('return the correct payload for trackInAppDelivery', async () => {
     const response = await trackInAppDelivery({
       messageId: '123',
@@ -103,6 +176,25 @@ describe('Events Requests', () => {
       WEB_PLATFORM
     );
     expect(response.data.msg).toBe('hello');
+  });
+
+  it('should reject trackInAppDelivery on bad params', async () => {
+    try {
+      await trackInAppDelivery({} as any);
+    } catch (e) {
+      expect(e).toEqual(
+        createClientError([
+          {
+            error: 'messageId is a required field',
+            field: 'messageId'
+          },
+          {
+            error: 'deviceInfo.appPackageName is a required field',
+            field: 'deviceInfo.appPackageName'
+          }
+        ])
+      );
+    }
   });
 
   it('return the correct payload for trackInAppOpen', async () => {
@@ -121,35 +213,60 @@ describe('Events Requests', () => {
     expect(response.data.msg).toBe('hello');
   });
 
+  it('should reject trackInAppOpen on bad params', async () => {
+    try {
+      await trackInAppOpen({} as any);
+    } catch (e) {
+      expect(e).toEqual(
+        createClientError([
+          {
+            error: 'messageId is a required field',
+            field: 'messageId'
+          },
+          {
+            error: 'deviceInfo.appPackageName is a required field',
+            field: 'deviceInfo.appPackageName'
+          }
+        ])
+      );
+    }
+  });
+
   it('should not send up passed email or userId params', async () => {
     const trackResponse = await track({
       email: 'hello@gmail.com',
       userId: '1234',
+      eventName: 'my-event',
       deviceInfo: { appPackageName: 'my-lil-site' }
     } as any);
     const trackClickResponse = await trackInAppClick({
       email: 'hello@gmail.com',
       userId: '1234',
+      messageId: 'fdsafd',
       deviceInfo: { appPackageName: 'my-lil-site' }
     } as any);
     const trackCloseResponse = await trackInAppClose({
       email: 'hello@gmail.com',
       userId: '1234',
+      messageId: 'fdsafd',
       deviceInfo: { appPackageName: 'my-lil-site' }
     } as any);
     const trackConsumeResponse = await trackInAppConsume({
       email: 'hello@gmail.com',
       userId: '1234',
+      messageId: 'fdsafd',
       deviceInfo: { appPackageName: 'my-lil-site' }
     } as any);
     const trackDeliveryResponse = await trackInAppDelivery({
       email: 'hello@gmail.com',
       userId: '1234',
+      messageId: 'fdsafd',
       deviceInfo: { appPackageName: 'my-lil-site' }
     } as any);
     const trackOpenResponse = await trackInAppOpen({
       email: 'hello@gmail.com',
       userId: '1234',
+      messageId: 'fdsafd',
       deviceInfo: { appPackageName: 'my-lil-site' }
     } as any);
 

--- a/src/events/events.ts
+++ b/src/events/events.ts
@@ -2,6 +2,7 @@ import { baseIterableRequest } from '../request';
 import { InAppEventRequestParams, InAppTrackRequestParams } from './types';
 import { IterableResponse } from '../types';
 import { WEB_PLATFORM } from '../constants';
+import { eventRequestSchema, trackSchema } from './events.schema';
 
 export const track = (payload: InAppTrackRequestParams) => {
   /* a customer could potentially send these up if they're not using TypeScript */
@@ -11,7 +12,10 @@ export const track = (payload: InAppTrackRequestParams) => {
   return baseIterableRequest<IterableResponse>({
     method: 'POST',
     url: '/events/track',
-    data: payload
+    data: payload,
+    validation: {
+      data: trackSchema
+    }
   });
 };
 
@@ -30,6 +34,9 @@ export const trackInAppClose = (payload: InAppEventRequestParams) => {
         platform: WEB_PLATFORM,
         deviceId: global.navigator.userAgent || ''
       }
+    },
+    validation: {
+      data: eventRequestSchema
     }
   });
 };
@@ -54,6 +61,13 @@ export const trackInAppOpen = (
         platform: WEB_PLATFORM,
         deviceId: global.navigator.userAgent || ''
       }
+    },
+    validation: {
+      data: eventRequestSchema.omit([
+        'clickedUrl',
+        'inboxSessionId',
+        'closeAction'
+      ])
     }
   });
 };
@@ -75,6 +89,9 @@ export const trackInAppClick = (
         platform: WEB_PLATFORM,
         deviceId: global.navigator.userAgent || ''
       }
+    },
+    validation: {
+      data: eventRequestSchema.omit(['inboxSessionId', 'closeAction'])
     }
   });
 };
@@ -99,6 +116,13 @@ export const trackInAppDelivery = (
         platform: WEB_PLATFORM,
         deviceId: global.navigator.userAgent || ''
       }
+    },
+    validation: {
+      data: eventRequestSchema.omit([
+        'clickedUrl',
+        'inboxSessionId',
+        'closeAction'
+      ])
     }
   });
 };
@@ -123,6 +147,13 @@ export const trackInAppConsume = (
         platform: WEB_PLATFORM,
         deviceId: global.navigator.userAgent || ''
       }
+    },
+    validation: {
+      data: eventRequestSchema.omit([
+        'clickedUrl',
+        'inboxSessionId',
+        'closeAction'
+      ])
     }
   });
 };

--- a/src/inapp/inapp.schema.ts
+++ b/src/inapp/inapp.schema.ts
@@ -5,7 +5,8 @@ export const inAppMessagesParamSchema = object().shape({
   onOpenScreenReaderMessage: string(),
   onOpenNodeToTakeFocus: string(),
   count: number().required(),
-  packageName: string().required()
+  packageName: string().required(),
+  platform: string().required()
 });
 
 export default inAppMessagesParamSchema;


### PR DESCRIPTION
## JIRA Ticket(s) if any

* [MOB-3104](https://iterable.atlassian.net/browse/MOB-3104)

## Description

Adds client-side validation for /commerce endpoints

## Test Steps

1. Run `yarn test`
2. Ensure tests pass

-----

Alternatively:

1. Make a `track`, `trackInAppOpen`, etc call
2. Omit some required field
3. See a promise rejection with the reason why in the payload. Example:

```ts
import { track } from '@iterable/web-sdk'

track([ { } ])
```