### PR TITLE
Add IFrame Button to Dismiss In-App Messages

### DIFF
--- a/example/src/index.ts
+++ b/example/src/index.ts
@@ -38,7 +38,7 @@ import {
         'hey screen reader here telling you something just popped up on your screen!',
       onOpenNodeToTakeFocus: 'input',
       packageName: 'my-lil-website'
-    } as any,
+    },
     true
   );
 


### PR DESCRIPTION
## JIRA Ticket(s) if any

* [MOB-3321](https://iterable.atlassian.net/browse/MOB-3321)

## Description

Adds fixed position button to iframe that when clicked dismisses the in-app message.

The reason is for the scenario where the user makes their in-app take less than 100% width of the iframe. In other words, if their in-app has this html: `<body style="width:50%;"> ... ` and there is blank space in the iframe.

This PR fills that blank space with a button that will dismiss the message, similar to the overlay wrapping the iframe.

## Test Steps

1. Create an in-app message with some HTML but make sure the body takes less than 100%.
   * The sample app should have one set up already FYI
2. Run example app and paint the message
3. Click the empty space
4. Ensure in-app message is dismissed