### PR TITLE
Rename initIdentify Method

### DIFF
--- a/EXAMPLE_APP.md
+++ b/EXAMPLE_APP.md
@@ -9,10 +9,10 @@ First thing you need to do is generate an API key on [the Iterable app](https://
 Then once you boot up the app with `yarn install:all && yarn start:all`, you can set the key with the following code snippet. Similar code already exists in [`./example/src/index.ts`](./example/src/index.ts), but feel free to edit and play with it:
 
 ```ts
-import { initIdentify } from '@iterable/web-sdk';
+import { initialize } from '@iterable/web-sdk';
 
 (() => {
-  const { clearAuthToken, setNewAuthToken } = initIdentify(process.env.API_KEY);
+  const { clearAuthToken, setNewAuthToken } = initialize(process.env.API_KEY);
 
   /* make your Iterable API requests here */
   doSomeRequest().then().catch()
@@ -21,7 +21,7 @@ import { initIdentify } from '@iterable/web-sdk';
   clearAuthToken();
 
   /* 
-    the initIdentify method also exposes a setNewAuthToken method 
+    the initialize method also exposes a setNewAuthToken method 
     if you want to set another key later on.
   */
   setNewAuthToken('my-new-api-key')

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Below are the methods this SDK exposes. See [Iterable's API Docs](https://api.it
 
 | Method Name           	| Description                                                                                                               	|
 |-----------------------	|---------------------------------------------------------------------------------------------------------------------------	|
-| [`initIdentify`](#initIdentify)        	| Method for identifying users and setting a JWT                                                                            	|
+| [`initialize`](#initialize)        	| Method for identifying users and setting a JWT                                                                            	|
 | [`updateCart`](#updateCart)          	| Update _shoppingCartItems_ field on user profile                                                                          	|
 | [`trackPurchase`](#trackPurchase)       	| Track purchase events                                                                                                     	|
 | [`track`](#track)               	| Track custom events                                                                                                       	|
@@ -58,12 +58,12 @@ Below are the methods this SDK exposes. See [Iterable's API Docs](https://api.it
 
 # Usage
 
-## initIdentify
+## initialize
 
 API:
 
 ```ts
-initIdentify: (authToken: string, generateJWT: ({ email?: string, userID?: string }) => Promise<string>) => { 
+initialize: (authToken: string, generateJWT: ({ email?: string, userID?: string }) => Promise<string>) => { 
   clearRefresh: () => void;
   setEmail: (email: string) => Promise<string>;
   setUserID: (userId: string) => Promise<string>;
@@ -74,7 +74,7 @@ initIdentify: (authToken: string, generateJWT: ({ email?: string, userID?: strin
 Example:
 
 ```ts
-const { clearRefresh, setEmail, setUserID, logout } = initIdentify(
+const { clearRefresh, setEmail, setUserID, logout } = initialize(
   'my-API-key',
   /* 
     _email_ will be defined if you call _setEmail_ 
@@ -335,10 +335,10 @@ First, we'll deal with the JWT Secret. Typically, you need some backend service 
 Once you have a JWT or a service that can generate a JWT automatically, you're ready to start making requests in the SDK. The syntax for that looks like this:
 
 ```ts
-import { initIdentify } from '@iterable/web-sdk'
+import { initialize } from '@iterable/web-sdk'
 
 (() => {
-  initIdentify(
+  initialize(
     'YOUR_API_KEY_HERE',
     () => Promise.resolve('YOUR_JWT_HERE')
   );
@@ -350,10 +350,10 @@ Now that we've set our authorization logic within our app, it's time to set the 
 The syntax for identifying a user by user ID looks like this:
 
 ```ts
-import { initIdentify } from '@iterable/web-sdk'
+import { initialize } from '@iterable/web-sdk'
 
 (() => {
-  const { setUserID, logout } = initIdentify(
+  const { setUserID, logout } = initialize(
     'YOUR_API_KEY_HERE',
     () => Promise.resolve('YOUR_JWT_HERE')
   );
@@ -375,10 +375,10 @@ import { initIdentify } from '@iterable/web-sdk'
 Doing this with an email is similar:
 
 ```ts
-import { initIdentify } from '@iterable/web-sdk'
+import { initialize } from '@iterable/web-sdk'
 
 (() => {
-  const { setEmail, logout } = initIdentify(
+  const { setEmail, logout } = initialize(
     'YOUR_API_KEY_HERE',
     () => Promise.resolve('YOUR_JWT_HERE')
   );
@@ -403,10 +403,10 @@ import { initIdentify } from '@iterable/web-sdk'
 Now let's put it altogether with an Iterable API method:
 
 ```ts
-import { initIdentify, track } from '@iterable/web-sdk'
+import { initialize, track } from '@iterable/web-sdk'
 
 (() => {
-  const { setUserID, logout } = initIdentify(
+  const { setUserID, logout } = initialize(
     'YOUR_API_KEY_HERE',
     () => Promise.resolve('YOUR_JWT_HERE')
   );
@@ -467,10 +467,10 @@ This SDK allows that. Simply call the `getMessages` method but pass `true` as th
 Normally to request a list of in-app messages, you'd make a request like this:
 
 ```ts
-import { initIdentify, getInAppMessages } from '@iterable/web-sdk';
+import { initialize, getInAppMessages } from '@iterable/web-sdk';
 
 (() => {
-  const { setUserID } = initIdentify(
+  const { setUserID } = initialize(
     'YOUR_API_KEY_HERE',
     () => Promise.resolve('YOUR_JWT_HERE')
   );
@@ -493,10 +493,10 @@ import { initIdentify, getInAppMessages } from '@iterable/web-sdk';
 In order to take advantage of the SDK showing them automatically, you would implement the same method in this way:
 
 ```ts
-import { initIdentify, getInAppMessages } from '@iterable/web-sdk';
+import { initialize, getInAppMessages } from '@iterable/web-sdk';
 
 (() => {
-  const { setUserID } = initIdentify(
+  const { setUserID } = initialize(
     'YOUR_API_KEY_HERE',
     () => Promise.resolve('YOUR_JWT_HERE')
   );
@@ -524,10 +524,10 @@ import { initIdentify, getInAppMessages } from '@iterable/web-sdk';
 Optionally, you can pass arguments to fine-tune how you want the messages to appear
 
 ```ts
-import { initIdentify, getInAppMessages } from '@iterable/web-sdk';
+import { initialize, getInAppMessages } from '@iterable/web-sdk';
 
 (() => {
-  const { setUserID } = initIdentify(
+  const { setUserID } = initialize(
     'YOUR_API_KEY_HERE',
     () => Promise.resolve('YOUR_JWT_HERE')
   );
@@ -562,10 +562,10 @@ import { initIdentify, getInAppMessages } from '@iterable/web-sdk';
 You can also pause and resume the messages stream if you like
 
 ```ts
-import { initIdentify, getInAppMessages } from '@iterable/web-sdk';
+import { initialize, getInAppMessages } from '@iterable/web-sdk';
 
 (() => {
-  const { setUserID } = initIdentify(
+  const { setUserID } = initialize(
     'YOUR_API_KEY_HERE',
     () => Promise.resolve('YOUR_JWT_HERE')
   );

--- a/example/src/index.ts
+++ b/example/src/index.ts
@@ -1,14 +1,14 @@
 import './styles/index.css';
 import axios from 'axios';
 import {
-  initIdentify,
+  initialize,
   getInAppMessages,
   updateUserEmail
 } from '@iterable/web-sdk';
 
 ((): void => {
   /* set token in the SDK */
-  const { setEmail, logout } = initIdentify(
+  const { setEmail, logout } = initialize(
     process.env.API_KEY || '',
     ({ email }) => {
       return axios

--- a/src/authorization/authorization.test.ts
+++ b/src/authorization/authorization.test.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
-import { initIdentify } from './authorization';
+import { initialize } from './authorization';
 import { baseAxiosRequest } from '../request';
 import { getInAppMessages } from '../inapp';
 import { track, trackInAppClose } from '../events';
@@ -53,7 +53,7 @@ describe('API Key Interceptors', () => {
 
   describe('non-JWT auth', () => {
     it('should add Api-Key header to all outgoing requests', async () => {
-      initIdentify('123');
+      initialize('123');
 
       const response = await getInAppMessages({
         count: 10,
@@ -63,7 +63,7 @@ describe('API Key Interceptors', () => {
     });
 
     it('should add Api-Key header to all outgoing requests with new token', async () => {
-      const { setNewAuthToken } = initIdentify('123');
+      const { setNewAuthToken } = initialize('123');
       setNewAuthToken('333');
 
       const response = await getInAppMessages({
@@ -74,7 +74,7 @@ describe('API Key Interceptors', () => {
     });
 
     it('should not add Api-Key header to all outgoing requests after cleared', async () => {
-      const { clearAuthToken } = initIdentify('123');
+      const { clearAuthToken } = initialize('123');
       clearAuthToken();
 
       const response = await getInAppMessages({
@@ -87,7 +87,7 @@ describe('API Key Interceptors', () => {
 
   describe('JWT auth', () => {
     it('should add Api-Key and Authorization headers to outgoing requests when setEmail is invoked', async () => {
-      const { setEmail } = initIdentify('123', () =>
+      const { setEmail } = initialize('123', () =>
         Promise.resolve(MOCK_JWT_KEY)
       );
 
@@ -104,7 +104,7 @@ describe('API Key Interceptors', () => {
     });
 
     it('should add Api-Key and Authorization headers to outgoing requests when setUserId is invoked', async () => {
-      const { setUserID } = initIdentify('123', () =>
+      const { setUserID } = initialize('123', () =>
         Promise.resolve(MOCK_JWT_KEY)
       );
 
@@ -127,7 +127,7 @@ describe('API Key Interceptors', () => {
       const mockGenerateJWT = jest
         .fn()
         .mockReturnValue(Promise.resolve(MOCK_JWT_KEY));
-      const { setEmail } = initIdentify('123', mockGenerateJWT);
+      const { setEmail } = initialize('123', mockGenerateJWT);
       await setEmail('hello@gmail.com');
 
       expect(mockGenerateJWT).toHaveBeenCalledTimes(1);
@@ -142,7 +142,7 @@ describe('API Key Interceptors', () => {
       const mockGenerateJWT = jest
         .fn()
         .mockReturnValue(Promise.resolve(MOCK_JWT_KEY));
-      const { setEmail, clearRefresh } = initIdentify('123', mockGenerateJWT);
+      const { setEmail, clearRefresh } = initialize('123', mockGenerateJWT);
       await setEmail('hello@gmail.com');
       clearRefresh();
 
@@ -158,7 +158,7 @@ describe('API Key Interceptors', () => {
       const mockGenerateJWT = jest
         .fn()
         .mockReturnValue(Promise.reject(MOCK_JWT_KEY));
-      const { setEmail } = initIdentify('123', mockGenerateJWT);
+      const { setEmail } = initialize('123', mockGenerateJWT);
 
       try {
         await setEmail('hello@gmail.com');
@@ -181,7 +181,7 @@ describe('API Key Interceptors', () => {
       const mockGenerateJW = jest
         .fn()
         .mockReturnValue(Promise.resolve(MOCK_JWT_KEY));
-      const { setEmail } = initIdentify('123', mockGenerateJW);
+      const { setEmail } = initialize('123', mockGenerateJW);
 
       try {
         await setEmail('hello@gmail.com');
@@ -199,7 +199,7 @@ describe('API Key Interceptors', () => {
       const mockGenerateJWT = jest
         .fn()
         .mockReturnValue(Promise.resolve(MOCK_JWT_KEY));
-      const { setEmail } = initIdentify('123', mockGenerateJWT);
+      const { setEmail } = initialize('123', mockGenerateJWT);
 
       await setEmail('hello@gmail.com');
       await updateUserEmail('helloworld@gmail.com');
@@ -214,7 +214,7 @@ describe('API Key Interceptors', () => {
       const mockGenerateJWT = jest
         .fn()
         .mockReturnValue(Promise.resolve(MOCK_JWT_KEY));
-      const { setEmail } = initIdentify('123', mockGenerateJWT);
+      const { setEmail } = initialize('123', mockGenerateJWT);
 
       await setEmail('hello@gmail.com');
       await updateUserEmail('helloworld@gmail.com');
@@ -238,7 +238,7 @@ describe('API Key Interceptors', () => {
       const mockGenerateJWT = jest
         .fn()
         .mockReturnValue(Promise.resolve(MOCK_JWT_KEY));
-      const { setEmail } = initIdentify('123', mockGenerateJWT);
+      const { setEmail } = initialize('123', mockGenerateJWT);
 
       await setEmail('hello@gmail.com');
       await updateUserEmail('helloworld@gmail.com');
@@ -277,7 +277,7 @@ describe('User Identification', () => {
 
     describe('logout', () => {
       it('logout method removes the email field from requests', async () => {
-        const { logout, setEmail } = initIdentify('123');
+        const { logout, setEmail } = initialize('123');
         setEmail('hello@gmail.com');
         logout();
 
@@ -289,7 +289,7 @@ describe('User Identification', () => {
       });
 
       it('logout method removes the userId field from requests', async () => {
-        const { logout, setUserID } = initIdentify('123');
+        const { logout, setUserID } = initialize('123');
         await setUserID('hello@gmail.com');
         logout();
 
@@ -303,7 +303,7 @@ describe('User Identification', () => {
 
     describe('setEmail', () => {
       it('adds email param to endpoint that need an email as a param', async () => {
-        const { setEmail } = initIdentify('123');
+        const { setEmail } = initialize('123');
         setEmail('hello@gmail.com');
 
         const response = await getInAppMessages({
@@ -316,7 +316,7 @@ describe('User Identification', () => {
 
       it('clears any previous interceptors if called twice', async () => {
         const spy = jest.spyOn(baseAxiosRequest.interceptors.request, 'eject');
-        const { setEmail } = initIdentify('123');
+        const { setEmail } = initialize('123');
         setEmail('hello@gmail.com');
         setEmail('new@gmail.com');
 
@@ -334,7 +334,7 @@ describe('User Identification', () => {
       });
 
       it('adds email body to endpoint that need an email as a body', async () => {
-        const { setEmail } = initIdentify('123');
+        const { setEmail } = initialize('123');
         setEmail('hello@gmail.com');
 
         mockRequest.onPost('/events/trackInAppClose').reply(200, {
@@ -373,7 +373,7 @@ describe('User Identification', () => {
       });
 
       it('adds currentEmail body to endpoint that need an currentEmail as a body', async () => {
-        const { setEmail } = initIdentify('123');
+        const { setEmail } = initialize('123');
         setEmail('hello@gmail.com');
 
         mockRequest.onPost('/users/updateEmail').reply(200, {
@@ -388,7 +388,7 @@ describe('User Identification', () => {
       });
 
       it('should add user.email param to endpoints that need it', async () => {
-        const { setEmail } = initIdentify('123');
+        const { setEmail } = initialize('123');
         setEmail('hello@gmail.com');
 
         mockRequest.onPost('/commerce/updateCart').reply(200, {
@@ -409,7 +409,7 @@ describe('User Identification', () => {
       });
 
       it('adds no email body or header information to unrelated endpoints', async () => {
-        const { setEmail } = initIdentify('123');
+        const { setEmail } = initialize('123');
         setEmail('hello@gmail.com');
 
         mockRequest.onPost('/users/hello').reply(200, {
@@ -430,7 +430,7 @@ describe('User Identification', () => {
       });
 
       it('should overwrite user ID set by setUserID', async () => {
-        const { setEmail, setUserID } = initIdentify('123');
+        const { setEmail, setUserID } = initialize('123');
         await setUserID('999');
         setEmail('hello@gmail.com');
 
@@ -448,7 +448,7 @@ describe('User Identification', () => {
         mockRequest.resetHistory();
       });
       it('adds userId param to endpoint that need an userId as a param', async () => {
-        const { setUserID } = initIdentify('123');
+        const { setUserID } = initialize('123');
         await setUserID('999');
 
         const response = await getInAppMessages({
@@ -460,7 +460,7 @@ describe('User Identification', () => {
 
       it('clears any previous interceptors if called twice', async () => {
         const spy = jest.spyOn(baseAxiosRequest.interceptors.request, 'eject');
-        const { setUserID } = initIdentify('123');
+        const { setUserID } = initialize('123');
         await setUserID('999');
         await setUserID('111');
 
@@ -478,7 +478,7 @@ describe('User Identification', () => {
       });
 
       it('adds userId param to endpoint that need an userId as a param', async () => {
-        const { setUserID } = initIdentify('123');
+        const { setUserID } = initialize('123');
         await setUserID('999');
 
         const response = await getInAppMessages({
@@ -489,7 +489,7 @@ describe('User Identification', () => {
       });
 
       it('adds userId body to endpoint that need an userId as a body', async () => {
-        const { setUserID } = initIdentify('123');
+        const { setUserID } = initialize('123');
         await setUserID('999');
 
         mockRequest.onPost('/events/trackInAppClose').reply(200, {
@@ -520,7 +520,7 @@ describe('User Identification', () => {
       });
 
       it('adds currentUserId body to endpoint that need an currentUserId as a body', async () => {
-        const { setUserID } = initIdentify('123');
+        const { setUserID } = initialize('123');
         await setUserID('999');
 
         mockRequest.onPost('/users/updateEmail').reply(200, {
@@ -532,7 +532,7 @@ describe('User Identification', () => {
       });
 
       it('should add user.userId param to endpoints that need it', async () => {
-        const { setUserID } = initIdentify('123');
+        const { setUserID } = initialize('123');
         await setUserID('999');
 
         mockRequest.onPost('/commerce/updateCart').reply(200, {
@@ -549,7 +549,7 @@ describe('User Identification', () => {
       });
 
       it('adds no userId body or header information to unrelated endpoints', async () => {
-        const { setUserID } = initIdentify('123');
+        const { setUserID } = initialize('123');
         await setUserID('999');
 
         mockRequest.onPost('/users/hello').reply(200, {
@@ -570,7 +570,7 @@ describe('User Identification', () => {
       });
 
       it('should overwrite email set by setEmail', async () => {
-        const { setEmail, setUserID } = initIdentify('123');
+        const { setEmail, setUserID } = initialize('123');
         setEmail('hello@gmail.com');
         await setUserID('999');
 
@@ -585,7 +585,7 @@ describe('User Identification', () => {
       it('should try /users/update 0 times if request to create a user fails', async () => {
         mockRequest.onPost('/users/update').reply(400, {});
 
-        const { setUserID } = initIdentify('123');
+        const { setUserID } = initialize('123');
         await setUserID('999');
 
         expect(
@@ -610,7 +610,7 @@ describe('User Identification', () => {
 
     describe('logout', () => {
       it('logout method removes the email field from requests', async () => {
-        const { logout, setEmail } = initIdentify('123', () =>
+        const { logout, setEmail } = initialize('123', () =>
           Promise.resolve(MOCK_JWT_KEY)
         );
         await setEmail('hello@gmail.com');
@@ -624,7 +624,7 @@ describe('User Identification', () => {
       });
 
       it('logout method removes the userId field from requests', async () => {
-        const { logout, setUserID } = initIdentify('123', () =>
+        const { logout, setUserID } = initialize('123', () =>
           Promise.resolve(MOCK_JWT_KEY)
         );
         await setUserID('hello@gmail.com');
@@ -640,7 +640,7 @@ describe('User Identification', () => {
 
     describe('setEmail', () => {
       it('adds email param to endpoint that need an email as a param', async () => {
-        const { setEmail } = initIdentify('123', () =>
+        const { setEmail } = initialize('123', () =>
           Promise.resolve(MOCK_JWT_KEY)
         );
         await setEmail('hello@gmail.com');
@@ -655,7 +655,7 @@ describe('User Identification', () => {
 
       it('clears any previous interceptors if called twice', async () => {
         const spy = jest.spyOn(baseAxiosRequest.interceptors.request, 'eject');
-        const { setEmail } = initIdentify('123', () =>
+        const { setEmail } = initialize('123', () =>
           Promise.resolve(MOCK_JWT_KEY)
         );
         await setEmail('hello@gmail.com');
@@ -675,7 +675,7 @@ describe('User Identification', () => {
       });
 
       it('adds email body to endpoint that need an email as a body', async () => {
-        const { setEmail } = initIdentify('123', () =>
+        const { setEmail } = initialize('123', () =>
           Promise.resolve(MOCK_JWT_KEY)
         );
         await setEmail('hello@gmail.com');
@@ -716,7 +716,7 @@ describe('User Identification', () => {
       });
 
       it('adds currentEmail body to endpoint that need an currentEmail as a body', async () => {
-        const { setEmail } = initIdentify('123', () =>
+        const { setEmail } = initialize('123', () =>
           Promise.resolve(MOCK_JWT_KEY)
         );
         await setEmail('hello@gmail.com');
@@ -733,7 +733,7 @@ describe('User Identification', () => {
       });
 
       it('should add user.email param to endpoints that need it', async () => {
-        const { setEmail } = initIdentify('123', () =>
+        const { setEmail } = initialize('123', () =>
           Promise.resolve(MOCK_JWT_KEY)
         );
         await setEmail('hello@gmail.com');
@@ -756,7 +756,7 @@ describe('User Identification', () => {
       });
 
       it('adds no email body or header information to unrelated endpoints', async () => {
-        const { setEmail } = initIdentify('123', () =>
+        const { setEmail } = initialize('123', () =>
           Promise.resolve(MOCK_JWT_KEY)
         );
         await setEmail('hello@gmail.com');
@@ -779,7 +779,7 @@ describe('User Identification', () => {
       });
 
       it('should overwrite user ID set by setUserID', async () => {
-        const { setEmail, setUserID } = initIdentify('123', () =>
+        const { setEmail, setUserID } = initialize('123', () =>
           Promise.resolve(MOCK_JWT_KEY)
         );
         await setUserID('999');
@@ -799,7 +799,7 @@ describe('User Identification', () => {
         mockRequest.resetHistory();
       });
       it('adds userId param to endpoint that need an userId as a param', async () => {
-        const { setUserID } = initIdentify('123', () =>
+        const { setUserID } = initialize('123', () =>
           Promise.resolve(MOCK_JWT_KEY)
         );
         await setUserID('999');
@@ -813,7 +813,7 @@ describe('User Identification', () => {
 
       it('clears any previous interceptors if called twice', async () => {
         const spy = jest.spyOn(baseAxiosRequest.interceptors.request, 'eject');
-        const { setUserID } = initIdentify('123', () =>
+        const { setUserID } = initialize('123', () =>
           Promise.resolve(MOCK_JWT_KEY)
         );
         await setUserID('999');
@@ -833,7 +833,7 @@ describe('User Identification', () => {
       });
 
       it('adds userId param to endpoint that need an userId as a param', async () => {
-        const { setUserID } = initIdentify('123', () =>
+        const { setUserID } = initialize('123', () =>
           Promise.resolve(MOCK_JWT_KEY)
         );
         await setUserID('999');
@@ -846,7 +846,7 @@ describe('User Identification', () => {
       });
 
       it('adds userId body to endpoint that need an userId as a body', async () => {
-        const { setUserID } = initIdentify('123', () =>
+        const { setUserID } = initialize('123', () =>
           Promise.resolve(MOCK_JWT_KEY)
         );
         await setUserID('999');
@@ -879,7 +879,7 @@ describe('User Identification', () => {
       });
 
       it('adds currentUserId body to endpoint that need an currentUserId as a body', async () => {
-        const { setUserID } = initIdentify('123', () =>
+        const { setUserID } = initialize('123', () =>
           Promise.resolve(MOCK_JWT_KEY)
         );
         await setUserID('999');
@@ -893,7 +893,7 @@ describe('User Identification', () => {
       });
 
       it('should add user.userId param to endpoints that need it', async () => {
-        const { setUserID } = initIdentify('123', () =>
+        const { setUserID } = initialize('123', () =>
           Promise.resolve(MOCK_JWT_KEY)
         );
         await setUserID('999');
@@ -912,7 +912,7 @@ describe('User Identification', () => {
       });
 
       it('adds no userId body or header information to unrelated endpoints', async () => {
-        const { setUserID } = initIdentify('123', () =>
+        const { setUserID } = initialize('123', () =>
           Promise.resolve(MOCK_JWT_KEY)
         );
         await setUserID('999');
@@ -935,7 +935,7 @@ describe('User Identification', () => {
       });
 
       it('should overwrite email set by setEmail', async () => {
-        const { setUserID, setEmail } = initIdentify('123', () =>
+        const { setUserID, setEmail } = initialize('123', () =>
           Promise.resolve(MOCK_JWT_KEY)
         );
         await setEmail('hello@gmail.com');
@@ -952,7 +952,7 @@ describe('User Identification', () => {
       it('should try /users/update 0 times if request to create a user fails', async () => {
         mockRequest.onPost('/users/update').reply(400, {});
 
-        const { setUserID } = initIdentify('123', () =>
+        const { setUserID } = initialize('123', () =>
           Promise.resolve(MOCK_JWT_KEY)
         );
         try {

--- a/src/authorization/authorization.ts
+++ b/src/authorization/authorization.ts
@@ -28,12 +28,12 @@ interface WithoutJWT {
   logout: () => void;
 }
 
-export function initIdentify(
+export function initialize(
   authToken: string,
   generateJWT: (payload: GenerateJWTPayload) => Promise<string>
 ): WithJWT;
-export function initIdentify(authToken: string): WithoutJWT;
-export function initIdentify(
+export function initialize(authToken: string): WithoutJWT;
+export function initialize(
   authToken: string,
   generateJWT?: (payload: GenerateJWTPayload) => Promise<string>
 ) {

--- a/src/inapp/tests/inapp.test.ts
+++ b/src/inapp/tests/inapp.test.ts
@@ -5,7 +5,7 @@ import MockAdapter from 'axios-mock-adapter';
 import { baseAxiosRequest } from '../../request';
 import { messages } from '../../__data__/inAppMessages';
 import { getInAppMessages } from '../inapp';
-import { initIdentify } from '../../authorization';
+import { initialize } from '../../authorization';
 import { WEB_PLATFORM } from '../../constants';
 import { createClientError } from '../../utils/testUtils';
 
@@ -473,7 +473,7 @@ describe('getInAppMessages', () => {
         { count: 10, packageName: 'my-lil-website' },
         true
       );
-      const { logout } = initIdentify('fdsafsd');
+      const { logout } = initialize('fdsafsd');
       await request();
 
       const iframe = document.getElementById(

--- a/src/inapp/types.ts
+++ b/src/inapp/types.ts
@@ -13,7 +13,7 @@ export interface InAppMessagesRequestParams extends SDKInAppMessagesParams {
   packageName: string;
   /* 
     email and userID params omitted in favor of using the "setEmail" 
-    or "setUserID" methods on the _initIdentify_ method
+    or "setUserID" methods on the _initialize_ method
   */
   //  email?: string;
   //  userId?: string


### PR DESCRIPTION
## JIRA Ticket(s) if any

* [MOB-3533](https://iterable.atlassian.net/browse/MOB-3533)

## Description

Rename `initIdentify` to `initialize` because the other SDKs call it that.

## Test Steps

1. Run `yarn test` and ensure tests still pass
2. Run web app with `yarn install:all && yarn start:all` and ensure painting messages still works