### PR TITLE
Add ENABLE_INAPP_CONSUME Environment Variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Optional environment variables for local development. Start by creating a
+# called .env and add these values to it and change them appropriately
+
+# BASE_URL="https://api.iterable.com/api"
+# ENABLE_INAPP_CONSUME=false

--- a/src/authorization/authorization.ts
+++ b/src/authorization/authorization.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 import { baseAxiosRequest } from '../request';
 import { updateUser } from 'src/users';
 import { clearMessages } from 'src/inapp';
-import { RETRY_USER_ATTEMPTS } from 'src/constants';
+import { IS_PRODUCTION, RETRY_USER_ATTEMPTS } from 'src/constants';
 import { getEpochDifferenceInMS, getEpochExpiryTimeInMS } from './utils';
 import { config } from '../utils/config';
 
@@ -38,8 +38,7 @@ export function initialize(
   generateJWT?: (payload: GenerateJWTPayload) => Promise<string>
 ) {
   const logLevel = config.getConfig('logLevel');
-  const isProductionMode = process.env.NODE_ENV === 'production';
-  if (!generateJWT && isProductionMode) {
+  if (!generateJWT && IS_PRODUCTION) {
     /* only let people use non-JWT mode if running the app locally */
     if (logLevel === 'verbose') {
       return console.error(

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,6 +6,18 @@ export const RETRY_USER_ATTEMPTS = 0;
 
 export const BASE_URL = process.env.BASE_URL || 'https://api.iterable.com/api';
 
+const GET_ENABLE_INAPP_CONSUME = () => {
+  try {
+    return JSON.parse(process.env.ENABLE_INAPP_CONSUME);
+  } catch {
+    return true;
+  }
+};
+
+export const ENABLE_INAPP_CONSUME = GET_ENABLE_INAPP_CONSUME();
+
+export const IS_PRODUCTION = process.env.NODE_ENV === 'production';
+
 /* 
   API payload _platform_ param which is send up automatically 
   with tracking and getMessage requests 

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -2,5 +2,6 @@ declare namespace NodeJS {
   export interface ProcessEnv {
     NODE_ENV: 'development' | 'production' | 'test';
     BASE_URL: string;
+    ENABLE_INAPP_CONSUME: string;
   }
 }

--- a/src/inapp/inapp.ts
+++ b/src/inapp/inapp.ts
@@ -17,14 +17,16 @@ import {
 } from './utils';
 import {
   trackInAppClick,
-  trackInAppClose
-  // trackInAppConsume,
-  // trackInAppOpen
+  trackInAppClose,
+  trackInAppConsume,
+  trackInAppOpen
 } from '../events';
 import {
   ANIMATION_DURATION,
   ANIMATION_STYLESHEET,
   DISPLAY_INTERVAL_DEFAULT,
+  ENABLE_INAPP_CONSUME,
+  IS_PRODUCTION,
   WEB_PLATFORM
 } from 'src/constants';
 import schema from './inapp.schema';
@@ -245,22 +247,33 @@ export function getInAppMessages(
 
             Also swallow any 400+ response errors. We don't care about them.
           */
-          // Promise.all(
-          //   !activeMessage?.saveToInbox
-          //     ? [
-          //         trackInAppOpen({
-          //           messageId: activeMessage.messageId
-          //         }),
-          //         trackInAppConsume({
-          //           messageId: activeMessage.messageId
-          //         })
-          //       ]
-          //     : [
-          //         trackInAppOpen({
-          //           messageId: activeMessage.messageId
-          //         })
-          //       ]
-          // ).catch((e) => e);
+          if (ENABLE_INAPP_CONSUME || IS_PRODUCTION) {
+            Promise.all(
+              !activeMessage?.saveToInbox
+                ? [
+                    trackInAppOpen({
+                      messageId: activeMessage.messageId,
+                      deviceInfo: {
+                        appPackageName: payload.packageName
+                      }
+                    }),
+                    trackInAppConsume({
+                      messageId: activeMessage.messageId,
+                      deviceInfo: {
+                        appPackageName: payload.packageName
+                      }
+                    })
+                  ]
+                : [
+                    trackInAppOpen({
+                      messageId: activeMessage.messageId,
+                      deviceInfo: {
+                        appPackageName: payload.packageName
+                      }
+                    })
+                  ]
+            ).catch((e) => e);
+          }
 
           /* now we'll add click tracking to _all_ anchor tags */
           const links =


### PR DESCRIPTION
## JIRA Ticket(s) if any

* [MOB-3170](https://iterable.atlassian.net/browse/MOB-3170)

## Description

Adds enviornment variable for opening/consuming in-app messages

This was added as a QOL enhancement for local development, so a developer doesn't have to have their in-apps marked as read and consumed if they are testing UI.

## Test Steps

1. Create root level `.env` file.
2. Add `ENABLE_INAPP_CONSUME` to the file
3. Change value to `true` or `false`
4. Run app `yarn install:all && yarn start:all`
5. Paint in-app messages
6. Ensure SDK observes environment variable when marking in-apps as read/consumed.

-----

1. Then build the SDK files with `yarn build`
2. `cd example && yarn start` to start _just_ the example app
3. Ensure in-app messages are consumed regardless of the environment variable
   * the production-ready SDK files should always consume the messages