### PR TITLE
Add Version to Requests

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -19,3 +19,5 @@ Object.defineProperty(global, 'navigator', {
     userAgent: 'some-user-agent'
   }
 });
+
+process.env.VERSION = 'mock-version';

--- a/src/authorization/authorization.ts
+++ b/src/authorization/authorization.ts
@@ -2,7 +2,11 @@ import axios from 'axios';
 import { baseAxiosRequest } from '../request';
 import { updateUser } from 'src/users';
 import { clearMessages } from 'src/inapp';
-import { IS_PRODUCTION, RETRY_USER_ATTEMPTS } from 'src/constants';
+import {
+  IS_PRODUCTION,
+  RETRY_USER_ATTEMPTS,
+  STATIC_HEADERS
+} from 'src/constants';
 import { getEpochDifferenceInMS, getEpochExpiryTimeInMS } from './utils';
 import { config } from '../utils/config';
 
@@ -453,6 +457,7 @@ export function initialize(
                     ...error.config,
                     headers: {
                       ...error.config.headers,
+                      ...STATIC_HEADERS,
                       'Api-Key': authToken,
                       Authorization: `Bearer ${newToken}`
                     }

--- a/src/commerce/commerce.test.ts
+++ b/src/commerce/commerce.test.ts
@@ -1,6 +1,7 @@
 import MockAdapter from 'axios-mock-adapter';
 import { baseAxiosRequest } from '../request';
 import { trackPurchase, updateCart } from './commerce';
+import { SDK_VERSION, WEB_PLATFORM } from '../constants';
 import { createClientError } from '../utils/testUtils';
 
 const mockRequest = new MockAdapter(baseAxiosRequest);
@@ -31,6 +32,8 @@ describe('Users Requests', () => {
       }
     ]);
     expect(JSON.parse(response.config.data).user.preferUserId).toBe(true);
+    expect(response.config.headers['SDK-Version']).toBe(SDK_VERSION);
+    expect(response.config.headers['SDK-Platform']).toBe(WEB_PLATFORM);
     expect(response.data.msg).toBe('hello');
   });
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -18,11 +18,18 @@ export const ENABLE_INAPP_CONSUME = GET_ENABLE_INAPP_CONSUME();
 
 export const IS_PRODUCTION = process.env.NODE_ENV === 'production';
 
+export const SDK_VERSION = process.env.VERSION;
+
 /* 
   API payload _platform_ param which is send up automatically 
   with tracking and getMessage requests 
 */
 export const WEB_PLATFORM = 'Web';
+
+export const STATIC_HEADERS = {
+  'SDK-Version': SDK_VERSION,
+  'SDK-Platform': WEB_PLATFORM
+};
 
 /* how long animations fade/side in for. */
 export const ANIMATION_DURATION = 400;

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -3,5 +3,6 @@ declare namespace NodeJS {
     NODE_ENV: 'development' | 'production' | 'test';
     BASE_URL: string;
     ENABLE_INAPP_CONSUME: string;
+    VERSION: string;
   }
 }

--- a/src/events/events.test.ts
+++ b/src/events/events.test.ts
@@ -8,7 +8,7 @@ import {
   trackInAppDelivery,
   trackInAppOpen
 } from './events';
-import { WEB_PLATFORM } from '../constants';
+import { SDK_VERSION, WEB_PLATFORM } from '../constants';
 import { createClientError } from '../utils/testUtils';
 
 const mockRequest = new MockAdapter(baseAxiosRequest);
@@ -39,6 +39,8 @@ describe('Events Requests', () => {
     const response = await track({ eventName: 'test' });
 
     expect(JSON.parse(response.config.data).eventName).toBe('test');
+    expect(response.config.headers['SDK-Version']).toBe(SDK_VERSION);
+    expect(response.config.headers['SDK-Platform']).toBe(WEB_PLATFORM);
     expect(response.data.msg).toBe('hello');
   });
 
@@ -71,6 +73,8 @@ describe('Events Requests', () => {
       WEB_PLATFORM
     );
     expect(response.data.msg).toBe('hello');
+    expect(response.config.headers['SDK-Version']).toBe(SDK_VERSION);
+    expect(response.config.headers['SDK-Platform']).toBe(WEB_PLATFORM);
   });
 
   it('should reject trackInAppClick on bad params', async () => {
@@ -106,6 +110,8 @@ describe('Events Requests', () => {
       WEB_PLATFORM
     );
     expect(response.data.msg).toBe('hello');
+    expect(response.config.headers['SDK-Version']).toBe(SDK_VERSION);
+    expect(response.config.headers['SDK-Platform']).toBe(WEB_PLATFORM);
   });
 
   it('should reject trackInAppClose on bad params', async () => {
@@ -141,6 +147,8 @@ describe('Events Requests', () => {
       WEB_PLATFORM
     );
     expect(response.data.msg).toBe('hello');
+    expect(response.config.headers['SDK-Version']).toBe(SDK_VERSION);
+    expect(response.config.headers['SDK-Platform']).toBe(WEB_PLATFORM);
   });
 
   it('should reject trackInAppConsume on bad params', async () => {
@@ -176,6 +184,8 @@ describe('Events Requests', () => {
       WEB_PLATFORM
     );
     expect(response.data.msg).toBe('hello');
+    expect(response.config.headers['SDK-Version']).toBe(SDK_VERSION);
+    expect(response.config.headers['SDK-Platform']).toBe(WEB_PLATFORM);
   });
 
   it('should reject trackInAppDelivery on bad params', async () => {
@@ -211,6 +221,8 @@ describe('Events Requests', () => {
       WEB_PLATFORM
     );
     expect(response.data.msg).toBe('hello');
+    expect(response.config.headers['SDK-Version']).toBe(SDK_VERSION);
+    expect(response.config.headers['SDK-Platform']).toBe(WEB_PLATFORM);
   });
 
   it('should reject trackInAppOpen on bad params', async () => {

--- a/src/inapp/inapp.ts
+++ b/src/inapp/inapp.ts
@@ -27,6 +27,7 @@ import {
   DISPLAY_INTERVAL_DEFAULT,
   ENABLE_INAPP_CONSUME,
   IS_PRODUCTION,
+  SDK_VERSION,
   WEB_PLATFORM
 } from 'src/constants';
 import schema from './inapp.schema';
@@ -363,7 +364,8 @@ export function getInAppMessages(
           },
           params: {
             ...dupedPayload,
-            platform: WEB_PLATFORM
+            platform: WEB_PLATFORM,
+            SDKVersion: SDK_VERSION
           }
         })
           .then((response) => {
@@ -422,7 +424,8 @@ export function getInAppMessages(
     },
     params: {
       ...dupedPayload,
-      platform: WEB_PLATFORM
+      platform: WEB_PLATFORM,
+      SDKVersion: SDK_VERSION
     }
   }).then((response) => {
     trackMessagesDelivered(

--- a/src/inapp/tests/inapp.test.ts
+++ b/src/inapp/tests/inapp.test.ts
@@ -6,7 +6,7 @@ import { baseAxiosRequest } from '../../request';
 import { messages } from '../../__data__/inAppMessages';
 import { getInAppMessages } from '../inapp';
 import { initialize } from '../../authorization';
-import { WEB_PLATFORM } from '../../constants';
+import { SDK_VERSION, WEB_PLATFORM } from '../../constants';
 import { createClientError } from '../../utils/testUtils';
 
 jest.mock('../../utils/srSpeak', () => ({
@@ -36,7 +36,10 @@ describe('getInAppMessages', () => {
 
       expect(response.config.params.packageName).toBe('my-lil-website');
       expect(response.config.params.platform).toBe(WEB_PLATFORM);
+      expect(response.config.params.SDKVersion).toBe(SDK_VERSION);
       expect(response.config.params.count).toBe(10);
+      expect(response.config.headers['SDK-Version']).toBe(SDK_VERSION);
+      expect(response.config.headers['SDK-Platform']).toBe(WEB_PLATFORM);
     });
 
     it('should reject if fails client-side validation', async () => {

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,5 +1,5 @@
 import Axios, { AxiosRequestConfig } from 'axios';
-import { BASE_URL } from './constants';
+import { BASE_URL, STATIC_HEADERS } from './constants';
 import { IterablePromise, IterableResponse } from './types';
 import { AnySchema, ValidationError } from 'yup';
 import { config } from './utils/config';
@@ -36,7 +36,11 @@ export const baseIterableRequest = <T = any>(
     }
     return baseAxiosRequest({
       ...payload,
-      baseURL: config.getConfig('baseURL') || BASE_URL
+      baseURL: config.getConfig('baseURL') || BASE_URL,
+      headers: {
+        ...payload.headers,
+        ...STATIC_HEADERS
+      }
     });
   } catch (error) {
     /* match Iterable's API error schema and add client errors as a new key */

--- a/src/users/users.test.ts
+++ b/src/users/users.test.ts
@@ -2,6 +2,7 @@ import MockAdapter from 'axios-mock-adapter';
 import { baseAxiosRequest } from '../request';
 import { updateSubscriptions, updateUser, updateUserEmail } from './users';
 import { createClientError } from '../utils/testUtils';
+import { SDK_VERSION, WEB_PLATFORM } from '../constants';
 
 const mockRequest = new MockAdapter(baseAxiosRequest);
 
@@ -17,6 +18,8 @@ describe('Users Requests', () => {
 
     expect(JSON.parse(response.config.data).dataFields).toEqual({});
     expect(JSON.parse(response.config.data).preferUserId).toBe(true);
+    expect(response.config.headers['SDK-Version']).toBe(SDK_VERSION);
+    expect(response.config.headers['SDK-Platform']).toBe(WEB_PLATFORM);
     expect(response.data.msg).toBe('hello');
   });
 
@@ -55,6 +58,8 @@ describe('Users Requests', () => {
 
     expect(JSON.parse(response.config.data).newEmail).toBe('hello@gmail.com');
     expect(response.data.msg).toBe('hello');
+    expect(response.config.headers['SDK-Version']).toBe(SDK_VERSION);
+    expect(response.config.headers['SDK-Platform']).toBe(WEB_PLATFORM);
   });
 
   it('should reject updateUserEmail on bad params', async () => {
@@ -101,6 +106,8 @@ describe('Users Requests', () => {
     expect(JSON.parse(response.config.data).campaignId).toBe(5);
     expect(JSON.parse(response.config.data).templateId).toBe(556);
     expect(response.data.msg).toBe('hello');
+    expect(response.config.headers['SDK-Version']).toBe(SDK_VERSION);
+    expect(response.config.headers['SDK-Platform']).toBe(WEB_PLATFORM);
   });
 
   it('should reject updateSubscriptions on bad params', async () => {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,18 @@
 const path = require('path');
 const env = require('dotenv').config({ path: './.env' });
 const webpack = require('webpack');
+const { version } = require('./package.json');
+
+function getParsedEnv() {
+  if (!env.error) {
+    return {
+      ...env.parsed,
+      version
+    };
+  }
+
+  return { version };
+}
 
 module.exports = {
   mode: 'production',
@@ -13,7 +25,7 @@ module.exports = {
   },
   plugins: [
     new webpack.DefinePlugin({
-      'process.env': JSON.stringify(!env.error ? env.parsed : {})
+      'process.env': JSON.stringify(getParsedEnv())
     })
   ]
 };

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -1,6 +1,18 @@
 const path = require('path');
 const env = require('dotenv').config({ path: './.env' });
 const webpack = require('webpack');
+const { version } = require('./package.json');
+
+function getParsedEnv() {
+  if (!env.error) {
+    return {
+      ...env.parsed,
+      version
+    };
+  }
+
+  return { version };
+}
 
 module.exports = {
   mode: 'development',
@@ -28,7 +40,7 @@ module.exports = {
   devtool: 'eval',
   plugins: [
     new webpack.DefinePlugin({
-      'process.env': JSON.stringify(!env.error ? env.parsed : {})
+      'process.env': JSON.stringify(getParsedEnv())
     })
   ]
 };

--- a/webpack.node.config.js
+++ b/webpack.node.config.js
@@ -1,13 +1,17 @@
 const path = require('path');
 const env = require('dotenv').config({ path: './.env' });
 const webpack = require('webpack');
+const { version } = require('./package.json');
 
 function getParsedEnv() {
   if (!env.error) {
-    return env.parsed;
+    return {
+      ...env.parsed,
+      version
+    };
   }
 
-  return {};
+  return { version };
 }
 
 module.exports = {


### PR DESCRIPTION
## JIRA Ticket(s) if any

* [MOB-3815](https://iterable.atlassian.net/browse/MOB-3815)

## Description

Adds `SDK-Platform` and `SDK-Version` as header to all requests

Adds `SDKVersion` to GET /getMessages query param

## Test Steps

1. Run example app locally
2. Make any request in app e.g:

```ts
import { updateCart } from '@iterable/web-sdk'

updateCart({ items: [] })
```

3. Ensure `SDK-Version` and `SDK-Platform` headers are sent up

------

1. Make `getInAppMessages()` request
2. Ensure `SDKVersion` query param is sent up