### PR TITLE
Fix handleLink Issue

### DIFF
--- a/example/src/index.ts
+++ b/example/src/index.ts
@@ -41,7 +41,7 @@ import {
       rightOffset: '20px',
       topOffset: '20px',
       bottomOffset: '20px',
-      handleLinks: 'open-all-new-tab'
+      handleLinks: 'external-new-tab'
     },
     true
   );

--- a/src/inapp/inapp.ts
+++ b/src/inapp/inapp.ts
@@ -346,8 +346,10 @@ export function getInAppMessages(
                       target="_blank" on all links, so we gave this option as an escape hatch for that.
                     */
                     const clickedHostname = getHostnameFromUrl(clickedUrl);
+                    /* !clickedHostname means the link was relative with no hostname */
                     const isInternalLink =
-                      clickedHostname === global.location.host;
+                      clickedHostname === global.location.host ||
+                      !clickedHostname;
 
                     if (
                       handleLinks === 'open-all-same-tab' ||

--- a/src/inapp/tests/utils.test.ts
+++ b/src/inapp/tests/utils.test.ts
@@ -880,6 +880,7 @@ describe('Utils', () => {
       expect(getHostnameFromUrl('http://localhost:8080/?name=fdsafdsaf')).toBe(
         'localhost:8080'
       );
+      expect(getHostnameFromUrl('/about')).toBe(undefined);
     });
   });
 });

--- a/src/inapp/utils.ts
+++ b/src/inapp/utils.ts
@@ -197,7 +197,7 @@ export const paintIFrame = (
       https://snook.ca/archives/html_and_css/hiding-content-for-accessibility 
     */
     iframe.style.cssText = `
-      position: absolute !important;
+      position: fixed !important;
       top: 0;
       left: 0;
       height: 1px;


### PR DESCRIPTION
## JIRA Ticket(s) if any

* [MOB-3837](https://iterable.atlassian.net/browse/MOB-3837)

## Description

Opens relative links in same tab if `{ handleLinks: 'external-new-tab' }` option exists

## Test Steps

1. Create inapp with relative link (e.g. "/about")
2. Set `{ handleLinks: 'external-new-tab' }` option in code
3. show message and click on link and ensure it opens in same tab