### PR TITLE
Abstract Common Cypress Setup

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,6 +1,6 @@
 node_modules
 dist
-index.js
-index.node.js
+/index.js
+/index.node.js
 index.d.ts
 jest.config.js

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 node_modules
 dist
-index.js
-index.node.js
+/index.js
+/index.node.js
 .env
 coverage
 hot

--- a/react-example/cypress/fixtures/commerce/200.json
+++ b/react-example/cypress/fixtures/commerce/200.json
@@ -1,5 +1,5 @@
 {
-  "msg": "",
+  "msg": "success mocked from cypress",
   "code": "Success",
   "params": {
     "id": "mock-cypress-id"

--- a/react-example/cypress/fixtures/commerce/400.json
+++ b/react-example/cypress/fixtures/commerce/400.json
@@ -1,6 +1,6 @@
 {
   "code": "GenericError",
-  "msg": "Client-side error",
+  "msg": "Client-side error mocked from cypress",
   "clientErrors": [
     {
       "error": "items[0].name is a required field",

--- a/react-example/cypress/fixtures/events/200.json
+++ b/react-example/cypress/fixtures/events/200.json
@@ -1,0 +1,5 @@
+{
+  "msg": "success mocked from cypress",
+  "code": "Success",
+  "params": null
+}

--- a/react-example/cypress/integration/commerce/commerce.spec.ts
+++ b/react-example/cypress/integration/commerce/commerce.spec.ts
@@ -5,20 +5,8 @@ describe('Track Purchase', () => {
         method: 'POST',
         url: '/api/commerce/trackPurchase*'
       },
-      { fixture: 'trackPurchase/200.json' }
+      { fixture: 'commerce/200.json' }
     ).as('trackPurchase');
-
-    cy.intercept(
-      {
-        url: '/generate*',
-        middleware: true
-      },
-      (req) => {
-        req.on('response', (res) => {
-          res.setThrottle(10000);
-        });
-      }
-    ).as('generateToken');
 
     cy.visit('/commerce');
 
@@ -29,7 +17,7 @@ describe('Track Purchase', () => {
 
     cy.get('[data-qa-purchase-response]').contains(
       JSON.stringify({
-        msg: '',
+        msg: 'success mocked from cypress',
         code: 'Success',
         params: {
           id: 'mock-cypress-id'
@@ -44,20 +32,8 @@ describe('Track Purchase', () => {
         method: 'POST',
         url: '/api/commerce/trackPurchase*'
       },
-      { fixture: 'trackPurchase/400.json' }
+      { fixture: 'commerce/400.json' }
     ).as('trackPurchase');
-
-    cy.intercept(
-      {
-        url: '/generate*',
-        middleware: true
-      },
-      (req) => {
-        req.on('response', (res) => {
-          res.setThrottle(10000);
-        });
-      }
-    ).as('generateToken');
 
     cy.visit('/commerce');
 
@@ -69,7 +45,7 @@ describe('Track Purchase', () => {
     cy.get('[data-qa-purchase-response]').contains(
       JSON.stringify({
         code: 'GenericError',
-        msg: 'Client-side error',
+        msg: 'Client-side error mocked from cypress',
         clientErrors: [
           { error: 'items[0].name is a required field', field: 'items[0].name' }
         ]
@@ -85,20 +61,8 @@ describe('Update Cart', () => {
         method: 'POST',
         url: '/api/commerce/updateCart*'
       },
-      { fixture: 'trackPurchase/200.json' }
+      { fixture: 'commerce/200.json' }
     ).as('updateCart');
-
-    cy.intercept(
-      {
-        url: '/generate*',
-        middleware: true
-      },
-      (req) => {
-        req.on('response', (res) => {
-          res.setThrottle(10000);
-        });
-      }
-    ).as('generateToken');
 
     cy.visit('/commerce');
 
@@ -109,7 +73,7 @@ describe('Update Cart', () => {
 
     cy.get('[data-qa-cart-response]').contains(
       JSON.stringify({
-        msg: '',
+        msg: 'success mocked from cypress',
         code: 'Success',
         params: {
           id: 'mock-cypress-id'
@@ -124,20 +88,8 @@ describe('Update Cart', () => {
         method: 'POST',
         url: '/api/commerce/updateCart*'
       },
-      { fixture: 'trackPurchase/400.json' }
+      { fixture: 'commerce/400.json' }
     ).as('updateCart');
-
-    cy.intercept(
-      {
-        url: '/generate*',
-        middleware: true
-      },
-      (req) => {
-        req.on('response', (res) => {
-          res.setThrottle(10000);
-        });
-      }
-    ).as('generateToken');
 
     cy.visit('/commerce');
 
@@ -149,7 +101,7 @@ describe('Update Cart', () => {
     cy.get('[data-qa-cart-response]').contains(
       JSON.stringify({
         code: 'GenericError',
-        msg: 'Client-side error',
+        msg: 'Client-side error mocked from cypress',
         clientErrors: [
           { error: 'items[0].name is a required field', field: 'items[0].name' }
         ]

--- a/react-example/cypress/support/index.js
+++ b/react-example/cypress/support/index.js
@@ -1,0 +1,30 @@
+/*
+  setup file for each test. These run before each and every test
+*/
+
+/* eslint-disable no-undef */
+beforeEach(() => {
+  cy.intercept(
+    {
+      url: '/generate*',
+    },
+    (req) => {
+      req.reply({
+        token: 'cypress-mock-token'
+      })
+    }
+  ).as('generateToken');
+
+  /* 
+    by default, just intercept all tracking events and 200 them 
+    so that we don't have to do this every time we paint in-app
+    messages to the screen.
+  */
+  cy.intercept(
+    {
+      method: 'POST',
+      url: '/api/events/track*'
+    },
+    { fixture: 'events/200.json' }
+  );
+});

--- a/react-example/src/index.tsx
+++ b/react-example/src/index.tsx
@@ -42,6 +42,9 @@ const HomeLink = styled(Link)`
         }
       )
       .then((response) => {
+        const div = document.createElement('div');
+        div.innerHTML = response.data.token;
+        document.body.appendChild(div);
         return response.data?.token;
       });
   });

--- a/react-example/src/index.tsx
+++ b/react-example/src/index.tsx
@@ -42,9 +42,6 @@ const HomeLink = styled(Link)`
         }
       )
       .then((response) => {
-        const div = document.createElement('div');
-        div.innerHTML = response.data.token;
-        document.body.appendChild(div);
         return response.data?.token;
       });
   });


### PR DESCRIPTION
## JIRA Ticket(s) if any

N/A

## Description

Abstracts common things that every cypress test needs to a setup file.

Essentially does 2 things:

1. intercepts all `/generate` requests so that the request to get a JWT token just auto-resolves without hitting a server
2. intercepts all tracking calls. When we eventually test in-app messages with cypress, i want to prevent any tracking calls to a server actually being made and just stub the `/getInAppMessages` call with mock HTML.

## Test Steps

1. Install deps and run react app with `yarn install:all && yarn start:all:react`
2. `cd ./react-example && yarn cypress`
3. In the cypress window, run all the test and make sure they all pass