### PR TITLE
Add Cypress Suite for Events Endpoints

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,4 @@
 dist
-index.js
-index.d.ts
-index.node.js
+/index.js
+/index.d.ts
+/index.node.js

--- a/react-example/cypress/fixtures/events/400.json
+++ b/react-example/cypress/fixtures/events/400.json
@@ -1,0 +1,10 @@
+{
+  "code": "GenericError",
+  "msg": "Client-side error mocked from cypress",
+  "clientErrors": [
+    {
+      "error": "eventName is a required field",
+      "field": "eventName"
+    }
+  ]
+}

--- a/react-example/cypress/integration/events/events.spec.ts
+++ b/react-example/cypress/integration/events/events.spec.ts
@@ -1,0 +1,52 @@
+describe('Track', () => {
+  it('should paint the correct 200 response', () => {
+    /* 
+      no need to intercept anything in this test. See ../../support/index.js 
+      where setup file is already intercepting this
+    */
+    cy.visit('/events');
+
+    cy.get('[data-qa-track-input]').type('mock-event');
+    cy.get('[data-qa-track-submit]').submit();
+
+    cy.wait('@track');
+
+    cy.get('[data-qa-track-response]').contains(
+      JSON.stringify({
+        msg: 'success mocked from cypress',
+        code: 'Success',
+        params: null
+      })
+    );
+  });
+
+  it('should paint the correct 400 response', () => {
+    cy.intercept(
+      {
+        method: 'POST',
+        url: '/api/events/track*'
+      },
+      { fixture: 'events/400.json' }
+    ).as('track');
+
+    cy.visit('/events');
+
+    cy.get('[data-qa-track-input]').type('SomeItem');
+    cy.get('[data-qa-track-submit]').submit();
+
+    cy.wait('@track');
+
+    cy.get('[data-qa-track-response]').contains(
+      JSON.stringify({
+        code: 'GenericError',
+        msg: 'Client-side error mocked from cypress',
+        clientErrors: [
+          {
+            error: 'eventName is a required field',
+            field: 'eventName'
+          }
+        ]
+      })
+    );
+  });
+});

--- a/react-example/cypress/integration/events/events.spec.ts
+++ b/react-example/cypress/integration/events/events.spec.ts
@@ -50,3 +50,325 @@ describe('Track', () => {
     );
   });
 });
+
+describe('Track Click', () => {
+  it('should paint the correct 200 response', () => {
+    /* 
+      no need to intercept anything in this test. See ../../support/index.js 
+      where setup file is already intercepting this
+    */
+    cy.visit('/events');
+
+    cy.get('[data-qa-track-click-input]').type('mock-event');
+    cy.get('[data-qa-track-click-submit]').submit();
+
+    cy.wait('@track');
+
+    cy.get('[data-qa-track-click-response]').contains(
+      JSON.stringify({
+        msg: 'success mocked from cypress',
+        code: 'Success',
+        params: null
+      })
+    );
+  });
+
+  it('should paint the correct 400 response', () => {
+    cy.intercept(
+      {
+        method: 'POST',
+        url: '/api/events/track*'
+      },
+      { fixture: 'events/400.json' }
+    ).as('track');
+
+    cy.visit('/events');
+
+    cy.get('[data-qa-track-click-input]').type('SomeItem');
+    cy.get('[data-qa-track-click-submit]').submit();
+
+    cy.wait('@track');
+
+    cy.get('[data-qa-track-click-response]').contains(
+      JSON.stringify({
+        code: 'GenericError',
+        msg: 'Client-side error mocked from cypress',
+        clientErrors: [
+          {
+            error: 'eventName is a required field',
+            field: 'eventName'
+          }
+        ]
+      })
+    );
+  });
+});
+
+describe('Track Click', () => {
+  it('should paint the correct 200 response', () => {
+    /* 
+      no need to intercept anything in this test. See ../../support/index.js 
+      where setup file is already intercepting this
+    */
+    cy.visit('/events');
+
+    cy.get('[data-qa-track-click-input]').type('mock-event');
+    cy.get('[data-qa-track-click-submit]').submit();
+
+    cy.wait('@track');
+
+    cy.get('[data-qa-track-click-response]').contains(
+      JSON.stringify({
+        msg: 'success mocked from cypress',
+        code: 'Success',
+        params: null
+      })
+    );
+  });
+
+  it('should paint the correct 400 response', () => {
+    cy.intercept(
+      {
+        method: 'POST',
+        url: '/api/events/track*'
+      },
+      { fixture: 'events/400.json' }
+    ).as('track');
+
+    cy.visit('/events');
+
+    cy.get('[data-qa-track-click-input]').type('SomeItem');
+    cy.get('[data-qa-track-click-submit]').submit();
+
+    cy.wait('@track');
+
+    cy.get('[data-qa-track-click-response]').contains(
+      JSON.stringify({
+        code: 'GenericError',
+        msg: 'Client-side error mocked from cypress',
+        clientErrors: [
+          {
+            error: 'eventName is a required field',
+            field: 'eventName'
+          }
+        ]
+      })
+    );
+  });
+});
+
+describe('Track Close', () => {
+  it('should paint the correct 200 response', () => {
+    /* 
+      no need to intercept anything in this test. See ../../support/index.js 
+      where setup file is already intercepting this
+    */
+    cy.visit('/events');
+
+    cy.get('[data-qa-track-close-input]').type('mock-event');
+    cy.get('[data-qa-track-close-submit]').submit();
+
+    cy.wait('@track');
+
+    cy.get('[data-qa-track-close-response]').contains(
+      JSON.stringify({
+        msg: 'success mocked from cypress',
+        code: 'Success',
+        params: null
+      })
+    );
+  });
+
+  it('should paint the correct 400 response', () => {
+    cy.intercept(
+      {
+        method: 'POST',
+        url: '/api/events/track*'
+      },
+      { fixture: 'events/400.json' }
+    ).as('track');
+
+    cy.visit('/events');
+
+    cy.get('[data-qa-track-close-input]').type('SomeItem');
+    cy.get('[data-qa-track-close-submit]').submit();
+
+    cy.wait('@track');
+
+    cy.get('[data-qa-track-close-response]').contains(
+      JSON.stringify({
+        code: 'GenericError',
+        msg: 'Client-side error mocked from cypress',
+        clientErrors: [
+          {
+            error: 'eventName is a required field',
+            field: 'eventName'
+          }
+        ]
+      })
+    );
+  });
+});
+
+describe('Track Consume', () => {
+  it('should paint the correct 200 response', () => {
+    cy.intercept(
+      {
+        method: 'POST',
+        url: '/api/events/inAppConsume*'
+      },
+      { fixture: 'events/200.json' }
+    ).as('track');
+
+    cy.visit('/events');
+
+    cy.get('[data-qa-track-consume-input]').type('mock-event');
+    cy.get('[data-qa-track-consume-submit]').submit();
+
+    cy.wait('@track');
+
+    cy.get('[data-qa-track-consume-response]').contains(
+      JSON.stringify({
+        msg: 'success mocked from cypress',
+        code: 'Success',
+        params: null
+      })
+    );
+  });
+
+  it('should paint the correct 400 response', () => {
+    cy.intercept(
+      {
+        method: 'POST',
+        url: '/api/events/inAppConsume*'
+      },
+      { fixture: 'events/400.json' }
+    ).as('track');
+
+    cy.visit('/events');
+
+    cy.get('[data-qa-track-consume-input]').type('SomeItem');
+    cy.get('[data-qa-track-consume-submit]').submit();
+
+    cy.wait('@track');
+
+    cy.get('[data-qa-track-consume-response]').contains(
+      JSON.stringify({
+        code: 'GenericError',
+        msg: 'Client-side error mocked from cypress',
+        clientErrors: [
+          {
+            error: 'eventName is a required field',
+            field: 'eventName'
+          }
+        ]
+      })
+    );
+  });
+});
+
+describe('Track Delivery', () => {
+  it('should paint the correct 200 response', () => {
+    /* 
+      no need to intercept anything in this test. See ../../support/index.js 
+      where setup file is already intercepting this
+    */
+    cy.visit('/events');
+
+    cy.get('[data-qa-track-delivery-input]').type('mock-event');
+    cy.get('[data-qa-track-delivery-submit]').submit();
+
+    cy.wait('@track');
+
+    cy.get('[data-qa-track-delivery-response]').contains(
+      JSON.stringify({
+        msg: 'success mocked from cypress',
+        code: 'Success',
+        params: null
+      })
+    );
+  });
+
+  it('should paint the correct 400 response', () => {
+    cy.intercept(
+      {
+        method: 'POST',
+        url: '/api/events/track*'
+      },
+      { fixture: 'events/400.json' }
+    ).as('track');
+
+    cy.visit('/events');
+
+    cy.get('[data-qa-track-delivery-input]').type('SomeItem');
+    cy.get('[data-qa-track-delivery-submit]').submit();
+
+    cy.wait('@track');
+
+    cy.get('[data-qa-track-delivery-response]').contains(
+      JSON.stringify({
+        code: 'GenericError',
+        msg: 'Client-side error mocked from cypress',
+        clientErrors: [
+          {
+            error: 'eventName is a required field',
+            field: 'eventName'
+          }
+        ]
+      })
+    );
+  });
+});
+
+describe('Track Open', () => {
+  it('should paint the correct 200 response', () => {
+    /* 
+      no need to intercept anything in this test. See ../../support/index.js 
+      where setup file is already intercepting this
+    */
+    cy.visit('/events');
+
+    cy.get('[data-qa-track-open-input]').type('mock-event');
+    cy.get('[data-qa-track-open-submit]').submit();
+
+    cy.wait('@track');
+
+    cy.get('[data-qa-track-open-response]').contains(
+      JSON.stringify({
+        msg: 'success mocked from cypress',
+        code: 'Success',
+        params: null
+      })
+    );
+  });
+
+  it('should paint the correct 400 response', () => {
+    cy.intercept(
+      {
+        method: 'POST',
+        url: '/api/events/track*'
+      },
+      { fixture: 'events/400.json' }
+    ).as('track');
+
+    cy.visit('/events');
+
+    cy.get('[data-qa-track-open-input]').type('SomeItem');
+    cy.get('[data-qa-track-open-submit]').submit();
+
+    cy.wait('@track');
+
+    cy.get('[data-qa-track-open-response]').contains(
+      JSON.stringify({
+        code: 'GenericError',
+        msg: 'Client-side error mocked from cypress',
+        clientErrors: [
+          {
+            error: 'eventName is a required field',
+            field: 'eventName'
+          }
+        ]
+      })
+    );
+  });
+});

--- a/react-example/cypress/support/index.js
+++ b/react-example/cypress/support/index.js
@@ -26,5 +26,5 @@ beforeEach(() => {
       url: '/api/events/track*'
     },
     { fixture: 'events/200.json' }
-  );
+  ).as('track');
 });

--- a/react-example/cypress/support/index.js
+++ b/react-example/cypress/support/index.js
@@ -6,12 +6,12 @@
 beforeEach(() => {
   cy.intercept(
     {
-      url: '/generate*',
+      url: '/generate*'
     },
     (req) => {
       req.reply({
         token: 'cypress-mock-token'
-      })
+      });
     }
   ).as('generateToken');
 

--- a/react-example/src/components/EventsForm.tsx
+++ b/react-example/src/components/EventsForm.tsx
@@ -1,0 +1,99 @@
+import { FC, FormEvent, useState } from 'react';
+import styled from 'styled-components';
+import { IterablePromise, IterableResponse } from '@iterable/web-sdk';
+import TextField from 'src/components/TextField';
+import Button from 'src/components/Button';
+
+interface Props {
+  endpointName: string;
+  heading: string;
+  method: (...args: any) => IterablePromise<IterableResponse>;
+}
+
+const Form = styled.form`
+  display: flex;
+  flex-flow: column;
+  width: 45%;
+
+  @media (max-width: 850px) {
+    width: 100%;
+  }
+`;
+
+const Response = styled.pre`
+  width: 45%;
+  white-space: break-spaces;
+
+  @media (max-width: 850px) {
+    width: 100%;
+  }
+`;
+
+const EndpointWrapper = styled.div`
+  display: flex;
+  flex-flow: row;
+  width: 100%;
+  justify-content: space-between;
+`;
+
+const Heading = styled.h2`
+  margin-top: 3em;
+`;
+
+export const EventsForm: FC<Props> = ({ method, endpointName, heading }) => {
+  const [trackResponse, setTrackResponse] = useState<string>(
+    'Endpoint JSON goes here'
+  );
+
+  const [trackEvent, setTrackEvent] = useState<string>('');
+
+  const [isTrackingEvent, setTrackingEvent] = useState<boolean>(false);
+
+  const handleTrack = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setTrackingEvent(true);
+    method({
+      eventName: trackEvent,
+      messageId: 'mock-id',
+      deviceInfo: {
+        appPackageName: 'my-website'
+      }
+    })
+      .then((response) => {
+        setTrackResponse(JSON.stringify(response.data));
+        setTrackingEvent(false);
+      })
+      .catch((e) => {
+        setTrackResponse(JSON.stringify(e.response.data));
+        setTrackingEvent(false);
+      });
+  };
+
+  const formAttr = { [`data-qa-${endpointName}-submit`]: true };
+  const inputAttr = { [`data-qa-${endpointName}-input`]: true };
+  const responseAttr = { [`data-qa-${endpointName}-response`]: true };
+
+  return (
+    <>
+      <Heading>POST {heading}</Heading>
+      <EndpointWrapper>
+        <Form onSubmit={handleTrack} {...formAttr}>
+          <label htmlFor="item-1">Enter Event Name</label>
+          <TextField
+            value={trackEvent}
+            onChange={(e) => setTrackEvent(e.target.value)}
+            id="item-1"
+            placeholder="e.g. button-clicked"
+            {...inputAttr}
+          />
+          <Button disabled={isTrackingEvent} type="submit">
+            Submit
+          </Button>
+        </Form>
+        <Response {...responseAttr}>{trackResponse}</Response>
+      </EndpointWrapper>
+    </>
+  );
+};
+
+export default EventsForm;

--- a/react-example/src/index.tsx
+++ b/react-example/src/index.tsx
@@ -2,6 +2,7 @@ import './styles/index.css';
 import axios from 'axios';
 import Home from 'src/views/Home';
 import Commerce from 'src/views/Commerce';
+import Events from 'src/views/Events';
 import ReactDOM from 'react-dom';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import Link from 'src/components/Link';
@@ -57,6 +58,7 @@ const HomeLink = styled(Link)`
           <Routes>
             <Route path="/" element={<Home />} />
             <Route path="/commerce" element={<Commerce />} />
+            <Route path="/events" element={<Events />} />
           </Routes>
         </RouteWrapper>
       </Wrapper>

--- a/react-example/src/views/Events.tsx
+++ b/react-example/src/views/Events.tsx
@@ -1,87 +1,47 @@
-import { FC, FormEvent, useState } from 'react';
-import TextField from 'src/components/TextField';
-import Button from 'src/components/Button';
-import styled from 'styled-components';
+import { FC } from 'react';
+import EventsForm from 'src/components/EventsForm';
 
-import { track } from '@iterable/web-sdk';
-
-const Form = styled.form`
-  display: flex;
-  flex-flow: column;
-  width: 45%;
-
-  @media (max-width: 850px) {
-    width: 100%;
-  }
-`;
-
-const Response = styled.pre`
-  width: 45%;
-  white-space: break-spaces;
-
-  @media (max-width: 850px) {
-    width: 100%;
-  }
-`;
-
-const EndpointWrapper = styled.div`
-  display: flex;
-  flex-flow: row;
-  width: 100%;
-  justify-content: space-between;
-`;
-
-const Heading = styled.h2`
-  margin-top: 3em;
-`;
+import {
+  track,
+  trackInAppClick,
+  trackInAppClose,
+  trackInAppConsume,
+  trackInAppDelivery,
+  trackInAppOpen
+} from '@iterable/web-sdk';
 
 interface Props {}
 
 export const Events: FC<Props> = () => {
-  const [trackResponse, setTrackResponse] = useState<string>(
-    'Endpoint JSON goes here'
-  );
-
-  const [trackEvent, setTrackEvent] = useState<string>('');
-
-  const [isTrackingEvent, setTrackingEvent] = useState<boolean>(false);
-
-  const handleTrack = (e: FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    setTrackingEvent(true);
-    track({
-      eventName: trackEvent
-    })
-      .then((response) => {
-        setTrackResponse(JSON.stringify(response.data));
-        setTrackingEvent(false);
-      })
-      .catch((e) => {
-        setTrackResponse(JSON.stringify(e.response.data));
-        setTrackingEvent(false);
-      });
-  };
-
   return (
     <>
       <h1>Events Endpoints</h1>
-      <Heading>POST /track</Heading>
-      <EndpointWrapper>
-        <Form onSubmit={handleTrack} data-qa-track-submit>
-          <label htmlFor="item-1">Enter Event Name</label>
-          <TextField
-            value={trackEvent}
-            onChange={(e) => setTrackEvent(e.target.value)}
-            id="item-1"
-            placeholder="e.g. button-clicked"
-            data-qa-track-input
-          />
-          <Button disabled={isTrackingEvent} type="submit">
-            Submit
-          </Button>
-        </Form>
-        <Response data-qa-track-response>{trackResponse}</Response>
-      </EndpointWrapper>
+      <EventsForm heading="/track" endpointName="track" method={track} />
+      <EventsForm
+        heading="/trackInAppClick"
+        endpointName="track-click"
+        method={trackInAppClick}
+      />
+      <EventsForm
+        heading="/trackInAppClose"
+        endpointName="track-close"
+        method={trackInAppClose}
+      />
+      <EventsForm
+        heading="/inAppConsume"
+        endpointName="track-consume"
+        method={trackInAppConsume}
+      />
+      <EventsForm
+        heading="/trackInAppDelivery"
+        endpointName="track-delivery"
+        method={trackInAppDelivery}
+      />
+      <EventsForm
+        heading="/trackInAppOpen"
+        endpointName="track-open"
+        method={trackInAppOpen}
+      />
     </>
   );
 };

--- a/react-example/src/views/Events.tsx
+++ b/react-example/src/views/Events.tsx
@@ -1,0 +1,89 @@
+import { FC, FormEvent, useState } from 'react';
+import TextField from 'src/components/TextField';
+import Button from 'src/components/Button';
+import styled from 'styled-components';
+
+import { track } from '@iterable/web-sdk';
+
+const Form = styled.form`
+  display: flex;
+  flex-flow: column;
+  width: 45%;
+
+  @media (max-width: 850px) {
+    width: 100%;
+  }
+`;
+
+const Response = styled.pre`
+  width: 45%;
+  white-space: break-spaces;
+
+  @media (max-width: 850px) {
+    width: 100%;
+  }
+`;
+
+const EndpointWrapper = styled.div`
+  display: flex;
+  flex-flow: row;
+  width: 100%;
+  justify-content: space-between;
+`;
+
+const Heading = styled.h2`
+  margin-top: 3em;
+`;
+
+interface Props {}
+
+export const Events: FC<Props> = () => {
+  const [trackResponse, setTrackResponse] = useState<string>(
+    'Endpoint JSON goes here'
+  );
+
+  const [trackEvent, setTrackEvent] = useState<string>('');
+
+  const [isTrackingEvent, setTrackingEvent] = useState<boolean>(false);
+
+  const handleTrack = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setTrackingEvent(true);
+    track({
+      eventName: trackEvent
+    })
+      .then((response) => {
+        setTrackResponse(JSON.stringify(response.data));
+        setTrackingEvent(false);
+      })
+      .catch((e) => {
+        setTrackResponse(JSON.stringify(e.response.data));
+        setTrackingEvent(false);
+      });
+  };
+
+  return (
+    <>
+      <h1>Events Endpoints</h1>
+      <Heading>POST /track</Heading>
+      <EndpointWrapper>
+        <Form onSubmit={handleTrack} data-qa-track-submit>
+          <label htmlFor="item-1">Enter Event Name</label>
+          <TextField
+            value={trackEvent}
+            onChange={(e) => setTrackEvent(e.target.value)}
+            id="item-1"
+            placeholder="e.g. button-clicked"
+            data-qa-track-input
+          />
+          <Button disabled={isTrackingEvent} type="submit">
+            Submit
+          </Button>
+        </Form>
+        <Response data-qa-track-response>{trackResponse}</Response>
+      </EndpointWrapper>
+    </>
+  );
+};
+
+export default Events;

--- a/react-example/src/views/Home.tsx
+++ b/react-example/src/views/Home.tsx
@@ -18,6 +18,9 @@ export const Home: FC<Props> = () => {
         <Link to="/commerce" renderAsButton>
           Commerce
         </Link>
+        <Link to="/events" renderAsButton>
+          Events
+        </Link>
       </Wrapper>
     </>
   );

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,4 +4,5 @@ export * from './inapp';
 export * from './request';
 export * from './events';
 export * from './commerce';
+export * from './types';
 export { config } from './utils/config';


### PR DESCRIPTION
## JIRA Ticket(s) if any

* [MOB-3929](https://iterable.atlassian.net/browse/MOB-3929)

## Description

Add Cypress Suite for Events Endpoints. Creates a base component to handle the forms for each endpoint and renders the form in `Events.tsx` with all the different /events endpoints

## Test Steps

1. Run `yarn install:all && yarn start:all:react` to start the app
2. `cd ./react-example && yarn cypress` to run the cypress test runner
3. Click start in the Cypress window and run the `events.spec.ts` suite
4. Ensure all tests pass