### PR TITLE
Remove Dry Run from Publish Action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,5 @@ jobs:
       - uses: JS-DevTools/npm-publish@v1
         with:
           token: ${{ secrets.NPM_TOKEN }}
-          dry-run: true
           check-version: true
           


### PR DESCRIPTION
## JIRA Ticket(s) if any

N/A

## Description

Removes `dry-run` option from NPM release GitHub action.

[Read more about `dry-run` here](https://github.com/marketplace/actions/npm-publish#input-parameters) but essentially what it does is do all the steps to create the bundle to publish to NPM without actually publishing it. Used primarily for testing purposes

## Test Steps

There is no way to test this now. Basically, we have to trigger the GitHub action which is only set to run upon creating Github releases