### PR TITLE
Persist /trackInAppClick When Navigating Away

### DIFF
--- a/src/events/events.ts
+++ b/src/events/events.ts
@@ -82,6 +82,7 @@ export const trackInAppClick = (
   return baseIterableRequest<IterableResponse>({
     method: 'POST',
     url: '/events/trackInAppClick',
+    sendBeacon: true,
     data: {
       ...payload,
       deviceInfo: {

--- a/src/events/events.ts
+++ b/src/events/events.ts
@@ -73,7 +73,8 @@ export const trackInAppOpen = (
 };
 
 export const trackInAppClick = (
-  payload: Omit<InAppEventRequestParams, 'inboxSessionId' | 'closeAction'>
+  payload: Omit<InAppEventRequestParams, 'inboxSessionId' | 'closeAction'>,
+  sendBeacon = false
 ) => {
   /* a customer could potentially send these up if they're not using TypeScript */
   delete (payload as any).userId;
@@ -82,7 +83,7 @@ export const trackInAppClick = (
   return baseIterableRequest<IterableResponse>({
     method: 'POST',
     url: '/events/trackInAppClick',
-    sendBeacon: true,
+    sendBeacon,
     data: {
       ...payload,
       deviceInfo: {

--- a/src/request.ts
+++ b/src/request.ts
@@ -9,6 +9,7 @@ interface ExtendedRequestConfig extends AxiosRequestConfig {
     data?: AnySchema;
     params?: AnySchema;
   };
+  sendBeacon?: boolean;
 }
 
 interface ClientError extends IterableResponse {
@@ -34,6 +35,16 @@ export const baseIterableRequest = <T = any>(
         abortEarly: false
       });
     }
+    if (payload.sendBeacon) {
+      const blob = new Blob([JSON.stringify(payload.data)], {
+        type: 'application/json; charset=UTF-8'
+      });
+      global.navigator.sendBeacon(
+        (config.getConfig('baseURL') || BASE_URL) + payload.url,
+        blob
+      );
+    }
+    delete payload.sendBeacon;
     return baseAxiosRequest({
       ...payload,
       baseURL: config.getConfig('baseURL') || BASE_URL,

--- a/src/request.ts
+++ b/src/request.ts
@@ -35,16 +35,6 @@ export const baseIterableRequest = <T = any>(
         abortEarly: false
       });
     }
-    if (payload.sendBeacon) {
-      const blob = new Blob([JSON.stringify(payload.data)], {
-        type: 'application/json; charset=UTF-8'
-      });
-      global.navigator.sendBeacon(
-        (config.getConfig('baseURL') || BASE_URL) + payload.url,
-        blob
-      );
-    }
-    delete payload.sendBeacon;
     return baseAxiosRequest({
       ...payload,
       baseURL: config.getConfig('baseURL') || BASE_URL,


### PR DESCRIPTION
## JIRA Ticket(s) if any

* [MOB-4071](https://iterable.atlassian.net/browse/MOB-4071)

## Description

Previously, when a user opened an in-app message and clicked on a link that was going to navigate them to a new URL in the same tab, the `/trackInAppClick` request would be called, but never finish because the page was being unmounted.

Now, we persist the request using the `fetch` API's `keepalive` flag. Essentially what it does is makes sure the request finishes even though the user navigated to a new page.

🚨  PLEASE NOTE: In the Devtools on your browser, the request will be labeled as "unknown" because the browser doesn't actual know if the request succeeded or failed, and neither do we. We just simply hope for the best 🚨 

<img width="701" alt="Screen Shot 2022-02-24 at 1 35 21 PM" src="https://user-images.githubusercontent.com/7387001/155611553-3a9d94dd-87f3-4d22-a9f1-1237a33dff2c.png">

## Test Steps

1. Send yourself a (non-proof) in-app message with a link that will navigate you in the same tab
   * e.g. `<a href="/about">hello</a>` or `<a href="localhost:8080/something">hello</a>`
2. Run the example app with `yarn install:all && yarn start:all`
3. Login and paint the in-app message to the screen
4. Click your same-tab link and then head over to https://app.iterable.com/users/lookup and find your user
5. Confirm that a click event was tracked even though you navigated away