### PR TITLE
Add Login Form to React Example App

### DIFF
--- a/react-example/src/components/Button.tsx
+++ b/react-example/src/components/Button.tsx
@@ -10,7 +10,6 @@ const _Button = styled.button`
   background-color: #63abfb;
   border: none;
   border-radius: 5px;
-  margin-top: 1em;
   padding: 1em;
   -webkit-box-shadow: 0 5px 0 0 #006be0fa;
   box-shadow: 0 5px 0 0 #006be0fa;

--- a/react-example/src/components/EventsForm.tsx
+++ b/react-example/src/components/EventsForm.tsx
@@ -1,46 +1,27 @@
 import { FC, FormEvent, useState } from 'react';
-import styled from 'styled-components';
+import {
+  Button,
+  EndpointWrapper,
+  Form,
+  Heading,
+  Response
+} from '../views/Components.styled';
 import { IterablePromise, IterableResponse } from '@iterable/web-sdk';
 import TextField from 'src/components/TextField';
-import Button from 'src/components/Button';
 
 interface Props {
   endpointName: string;
   heading: string;
+  needsEventName?: boolean;
   method: (...args: any) => IterablePromise<IterableResponse>;
 }
 
-const Form = styled.form`
-  display: flex;
-  flex-flow: column;
-  width: 45%;
-
-  @media (max-width: 850px) {
-    width: 100%;
-  }
-`;
-
-const Response = styled.pre`
-  width: 45%;
-  white-space: break-spaces;
-
-  @media (max-width: 850px) {
-    width: 100%;
-  }
-`;
-
-const EndpointWrapper = styled.div`
-  display: flex;
-  flex-flow: row;
-  width: 100%;
-  justify-content: space-between;
-`;
-
-const Heading = styled.h2`
-  margin-top: 3em;
-`;
-
-export const EventsForm: FC<Props> = ({ method, endpointName, heading }) => {
+export const EventsForm: FC<Props> = ({
+  method,
+  endpointName,
+  heading,
+  needsEventName
+}) => {
   const [trackResponse, setTrackResponse] = useState<string>(
     'Endpoint JSON goes here'
   );
@@ -52,9 +33,12 @@ export const EventsForm: FC<Props> = ({ method, endpointName, heading }) => {
   const handleTrack = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setTrackingEvent(true);
+
+    const conditionalParams = needsEventName
+      ? { eventName: trackEvent }
+      : { messageId: trackEvent };
     method({
-      eventName: trackEvent,
-      messageId: 'mock-id',
+      ...conditionalParams,
       deviceInfo: {
         appPackageName: 'my-website'
       }
@@ -78,12 +62,14 @@ export const EventsForm: FC<Props> = ({ method, endpointName, heading }) => {
       <Heading>POST {heading}</Heading>
       <EndpointWrapper>
         <Form onSubmit={handleTrack} {...formAttr}>
-          <label htmlFor="item-1">Enter Event Name</label>
+          <label htmlFor="item-1">
+            {needsEventName ? 'Enter Event Name' : 'Enter Message ID'}
+          </label>
           <TextField
             value={trackEvent}
             onChange={(e) => setTrackEvent(e.target.value)}
             id="item-1"
-            placeholder="e.g. button-clicked"
+            placeholder={needsEventName ? 'e.g. button-clicked' : 'e.g. df3fe3'}
             {...inputAttr}
           />
           <Button disabled={isTrackingEvent} type="submit">

--- a/react-example/src/components/Link.tsx
+++ b/react-example/src/components/Link.tsx
@@ -3,6 +3,7 @@ import { Link as _Link, LinkProps } from 'react-router-dom';
 import styled from 'styled-components';
 
 const _ButtonLink = styled(_Link)`
+  font-family: sans-serif;
   text-align: center;
   text-decoration: none;
   width: 60%;
@@ -11,7 +12,6 @@ const _ButtonLink = styled(_Link)`
   background-color: #63abfb;
   border: none;
   border-radius: 5px;
-  margin-top: 1em;
   padding: 1em;
   -webkit-box-shadow: 0 5px 0 0 #006be0fa;
   box-shadow: 0 5px 0 0 #006be0fa;

--- a/react-example/src/components/LoginForm.tsx
+++ b/react-example/src/components/LoginForm.tsx
@@ -1,0 +1,98 @@
+import { FC, FormEvent, useState } from 'react';
+import styled from 'styled-components';
+
+import _TextField from 'src/components/TextField';
+import _Button from 'src/components/Button';
+
+const TextField = styled(_TextField)``;
+
+const Button = styled(_Button)`
+  margin-left: 0.4em;
+  max-width: 425px;
+`;
+
+const Form = styled.form`
+  display: flex;
+  flex-flow: row;
+  align-items: center;
+  justify-content: flex-end;
+  height: 100%;
+
+  ${TextField} {
+    align-self: stretch;
+    margin-top: 5px;
+  }
+`;
+
+interface Props {
+  setEmail: (email: string) => Promise<any>;
+}
+
+export const LoginForm: FC<Props> = ({ setEmail }) => {
+  const [email, updateEmail] = useState<string>('');
+  const [loggedInUser, setLoggedInUser] = useState<string>('');
+
+  const [isEditingUser, setEditingUser] = useState<boolean>(false);
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setEditingUser(false);
+
+    setEmail(email)
+      .then(() => {
+        setLoggedInUser(email);
+        updateEmail('');
+      })
+      .catch(() => updateEmail('Something went wrong!'));
+  };
+
+  const handleEditUser = () => {
+    updateEmail(loggedInUser);
+    setEditingUser(true);
+  };
+
+  const handleCancelEditUser = () => {
+    updateEmail('');
+    setEditingUser(false);
+  };
+
+  const first5 = loggedInUser.substring(0, 5);
+  const last9 = loggedInUser.substring(loggedInUser.length - 9);
+
+  return (
+    <>
+      {loggedInUser ? (
+        isEditingUser ? (
+          <Form onSubmit={handleSubmit}>
+            <TextField
+              onChange={(e) => updateEmail(e.target.value)}
+              value={email}
+              placeholder="e.g. hello@gmail.com"
+              type="email"
+              required
+            />
+            <Button type="submit">Change</Button>
+            <Button onClick={handleCancelEditUser}>Cancel</Button>
+          </Form>
+        ) : (
+          <Button onClick={handleEditUser}>
+            Logged In As {`${first5}...${last9}`} (change)
+          </Button>
+        )
+      ) : (
+        <Form onSubmit={handleSubmit}>
+          <TextField
+            onChange={(e) => updateEmail(e.target.value)}
+            value={email}
+            placeholder="e.g. hello@gmail.com"
+            type="email"
+            required
+          />
+          <Button type="submit">Login</Button>
+        </Form>
+      )}
+    </>
+  );
+};
+
+export default LoginForm;

--- a/react-example/src/components/TextField.tsx
+++ b/react-example/src/components/TextField.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 const Input = styled.input`
   padding: 0.8em;
   font-size: 16px;
+  box-sizing: border-box;
 `;
 
 interface Props extends InputHTMLAttributes<HTMLInputElement> {}

--- a/react-example/src/index.tsx
+++ b/react-example/src/index.tsx
@@ -1,14 +1,15 @@
-import './styles/index.css';
+import { initialize } from '@iterable/web-sdk';
 import axios from 'axios';
+import ReactDOM from 'react-dom';
+import './styles/index.css';
+
 import Home from 'src/views/Home';
 import Commerce from 'src/views/Commerce';
 import Events from 'src/views/Events';
-import ReactDOM from 'react-dom';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import Link from 'src/components/Link';
 import styled from 'styled-components';
-
-import { initialize } from '@iterable/web-sdk';
+import LoginForm from 'src/components/LoginForm';
 
 const Wrapper = styled.div`
   display: flex;
@@ -20,10 +21,17 @@ const RouteWrapper = styled.div`
   margin: 0 auto;
 `;
 
-const HomeLink = styled(Link)`
-  align-self: flex-end;
-  width: 100px;
+const HeaderWrapper = styled.div`
+  display: flex;
+  flex-flow: row;
+  align-items: center;
+  justify-content: flex-end;
   margin: 1em;
+`;
+
+const HomeLink = styled(Link)`
+  width: 100px;
+  margin-left: 0.8em;
 `;
 
 ((): void => {
@@ -47,13 +55,15 @@ const HomeLink = styled(Link)`
       });
   });
 
-  setEmail('iterable.tester@gmail.com');
   ReactDOM.render(
     <BrowserRouter>
       <Wrapper>
-        <HomeLink renderAsButton to="/">
-          Home
-        </HomeLink>
+        <HeaderWrapper>
+          <LoginForm setEmail={setEmail} />
+          <HomeLink renderAsButton to="/">
+            Home
+          </HomeLink>
+        </HeaderWrapper>
         <RouteWrapper>
           <Routes>
             <Route path="/" element={<Home />} />

--- a/react-example/src/views/Commerce.tsx
+++ b/react-example/src/views/Commerce.tsx
@@ -1,39 +1,14 @@
 import { FC, FormEvent, useState } from 'react';
 import TextField from 'src/components/TextField';
-import Button from 'src/components/Button';
-import styled from 'styled-components';
+import {
+  Button,
+  EndpointWrapper,
+  Form,
+  Heading,
+  Response
+} from './Components.styled';
 
 import { updateCart, trackPurchase } from '@iterable/web-sdk';
-
-const Form = styled.form`
-  display: flex;
-  flex-flow: column;
-  width: 45%;
-
-  @media (max-width: 850px) {
-    width: 100%;
-  }
-`;
-
-const Response = styled.pre`
-  width: 45%;
-  white-space: break-spaces;
-
-  @media (max-width: 850px) {
-    width: 100%;
-  }
-`;
-
-const EndpointWrapper = styled.div`
-  display: flex;
-  flex-flow: row;
-  width: 100%;
-  justify-content: space-between;
-`;
-
-const Heading = styled.h2`
-  margin-top: 3em;
-`;
 
 interface Props {}
 

--- a/react-example/src/views/Components.styled.ts
+++ b/react-example/src/views/Components.styled.ts
@@ -1,0 +1,36 @@
+import styled from 'styled-components';
+import _Button from 'src/components/Button';
+
+export const Form = styled.form`
+  display: flex;
+  flex-flow: column;
+  width: 45%;
+
+  @media (max-width: 850px) {
+    width: 100%;
+  }
+`;
+
+export const Response = styled.pre`
+  width: 45%;
+  white-space: break-spaces;
+
+  @media (max-width: 850px) {
+    width: 100%;
+  }
+`;
+
+export const EndpointWrapper = styled.div`
+  display: flex;
+  flex-flow: row;
+  width: 100%;
+  justify-content: space-between;
+`;
+
+export const Heading = styled.h2`
+  margin-top: 3em;
+`;
+
+export const Button = styled(_Button)`
+  margin-top: 1em;
+`;

--- a/react-example/src/views/Events.tsx
+++ b/react-example/src/views/Events.tsx
@@ -16,7 +16,12 @@ export const Events: FC<Props> = () => {
   return (
     <>
       <h1>Events Endpoints</h1>
-      <EventsForm heading="/track" endpointName="track" method={track} />
+      <EventsForm
+        heading="/track"
+        endpointName="track"
+        method={track}
+        needsEventName
+      />
       <EventsForm
         heading="/trackInAppClick"
         endpointName="track-click"

--- a/react-example/src/views/Home.tsx
+++ b/react-example/src/views/Home.tsx
@@ -1,11 +1,15 @@
 import { FC } from 'react';
-import Link from 'src/components/Link';
+import _Link from 'src/components/Link';
 import styled from 'styled-components';
 
 const Wrapper = styled.div`
   display: flex;
   flex-flow: column;
   align-items: center;
+`;
+
+const Link = styled(_Link)`
+  margin-top: 1em;
 `;
 
 interface Props {}


### PR DESCRIPTION
## JIRA Ticket(s) if any

* [MOB-3930](https://iterable.atlassian.net/browse/MOB-3930)

## Description

Adds login form to example app as a precursor the to the users endpoints form, so we can start manipulating the logged in user

## Test Steps

1. Run a local JWT generation backend by [cloning this repo](https://github.com/Iterable/jwt-generator) and running `docker-compose up -d`
2. Run react example app in this repo with `yarn install:all && yarn start:all:react`
3. Open up `localhost:8080` in your browser and use the login form in the header to login with an email
4. Using either commerce or events page, fill out any form and make an API request and ensure request went out with the user you logged in with
5. Then change your user and repeat step 4.
6. Ensure new request went out with your new email