### PR TITLE
Add Users Cypress Suite for React Example App

### DIFF
--- a/react-example/cypress/fixtures/users/200.json
+++ b/react-example/cypress/fixtures/users/200.json
@@ -1,0 +1,5 @@
+{
+  "msg": "success mocked from cypress",
+  "code": "Success",
+  "params": null
+}

--- a/react-example/cypress/fixtures/users/400.json
+++ b/react-example/cypress/fixtures/users/400.json
@@ -1,5 +1,5 @@
 {
-  "msg": "No API key found on request",
-  "code": "BadApiKey",
-  "params": { "ip": "68.111.205.112", "endpoint": "/api/users/update" }
+  "msg": "error mocked from cypress!",
+  "code": "CypressError",
+  "params": {  }
 }

--- a/react-example/cypress/fixtures/users/400.json
+++ b/react-example/cypress/fixtures/users/400.json
@@ -1,0 +1,5 @@
+{
+  "msg": "No API key found on request",
+  "code": "BadApiKey",
+  "params": { "ip": "68.111.205.112", "endpoint": "/api/users/update" }
+}

--- a/react-example/cypress/integration/users/users.spec.ts
+++ b/react-example/cypress/integration/users/users.spec.ts
@@ -42,9 +42,9 @@ describe('Update User', () => {
 
     cy.get('[data-qa-update-user-response]').contains(
       JSON.stringify({
-        msg: 'No API key found on request',
-        code: 'BadApiKey',
-        params: { ip: '68.111.205.112', endpoint: '/api/users/update' }
+        msg: 'error mocked from cypress!',
+        code: 'CypressError',
+        params: {}
       })
     );
   });
@@ -94,9 +94,9 @@ describe('Update User Email', () => {
 
     cy.get('[data-qa-update-user-email-response]').contains(
       JSON.stringify({
-        msg: 'No API key found on request',
-        code: 'BadApiKey',
-        params: { ip: '68.111.205.112', endpoint: '/api/users/update' }
+        msg: 'error mocked from cypress!',
+        code: 'CypressError',
+        params: {}
       })
     );
   });
@@ -146,9 +146,9 @@ describe('Update Subscriptions', () => {
 
     cy.get('[data-qa-update-subscriptions-response]').contains(
       JSON.stringify({
-        msg: 'No API key found on request',
-        code: 'BadApiKey',
-        params: { ip: '68.111.205.112', endpoint: '/api/users/update' }
+        msg: 'error mocked from cypress!',
+        code: 'CypressError',
+        params: {}
       })
     );
   });

--- a/react-example/cypress/integration/users/users.spec.ts
+++ b/react-example/cypress/integration/users/users.spec.ts
@@ -1,0 +1,155 @@
+describe('Update User', () => {
+  it('should paint 200 response data to screen', () => {
+    cy.intercept(
+      {
+        method: 'POST',
+        url: '/api/users/update*'
+      },
+      { fixture: 'users/200.json' }
+    ).as('updateUser');
+
+    cy.visit('/users');
+
+    cy.get('[data-qa-update-user-input]').type('SomeItem');
+    cy.get('[data-qa-update-user-submit]').submit();
+
+    cy.wait('@updateUser');
+
+    cy.get('[data-qa-update-user-response]').contains(
+      JSON.stringify({
+        msg: 'success mocked from cypress',
+        code: 'Success',
+        params: null
+      })
+    );
+  });
+
+  it('should paint 400 response data to screen', () => {
+    cy.intercept(
+      {
+        method: 'POST',
+        url: '/api/users/update*'
+      },
+      { fixture: 'users/400.json' }
+    ).as('updateUser');
+
+    cy.visit('/users');
+
+    cy.get('[data-qa-update-user-input]').type('SomeItem');
+    cy.get('[data-qa-update-user-submit]').submit();
+
+    cy.wait('@updateUser');
+
+    cy.get('[data-qa-update-user-response]').contains(
+      JSON.stringify({
+        msg: 'No API key found on request',
+        code: 'BadApiKey',
+        params: { ip: '68.111.205.112', endpoint: '/api/users/update' }
+      })
+    );
+  });
+});
+
+describe('Update User Email', () => {
+  it('should paint 200 response data to screen', () => {
+    cy.intercept(
+      {
+        method: 'POST',
+        url: '/api/users/updateEmail*'
+      },
+      { fixture: 'users/200.json' }
+    ).as('updateUserEmail');
+
+    cy.visit('/users');
+
+    cy.get('[data-qa-update-user-email-input]').type('SomeItem');
+    cy.get('[data-qa-update-user-email-submit]').submit();
+
+    cy.wait('@updateUserEmail');
+
+    cy.get('[data-qa-update-user-email-response]').contains(
+      JSON.stringify({
+        msg: 'success mocked from cypress',
+        code: 'Success',
+        params: null
+      })
+    );
+  });
+
+  it('should paint 400 response data to screen', () => {
+    cy.intercept(
+      {
+        method: 'POST',
+        url: '/api/users/updateEmail*'
+      },
+      { fixture: 'users/400.json' }
+    ).as('updateUserEmail');
+
+    cy.visit('/users');
+
+    cy.get('[data-qa-update-user-email-input]').type('SomeItem');
+    cy.get('[data-qa-update-user-email-submit]').submit();
+
+    cy.wait('@updateUserEmail');
+
+    cy.get('[data-qa-update-user-email-response]').contains(
+      JSON.stringify({
+        msg: 'No API key found on request',
+        code: 'BadApiKey',
+        params: { ip: '68.111.205.112', endpoint: '/api/users/update' }
+      })
+    );
+  });
+});
+
+describe('Update Subscriptions', () => {
+  it('should paint 200 response data to screen', () => {
+    cy.intercept(
+      {
+        method: 'POST',
+        url: '/api/users/updateSubscriptions*'
+      },
+      { fixture: 'users/200.json' }
+    ).as('updateSubscriptions');
+
+    cy.visit('/users');
+
+    cy.get('[data-qa-update-subscriptions-input]').type('10');
+    cy.get('[data-qa-update-subscriptions-submit]').submit();
+
+    cy.wait('@updateSubscriptions');
+
+    cy.get('[data-qa-update-subscriptions-response]').contains(
+      JSON.stringify({
+        msg: 'success mocked from cypress',
+        code: 'Success',
+        params: null
+      })
+    );
+  });
+
+  it('should paint 400 response data to screen', () => {
+    cy.intercept(
+      {
+        method: 'POST',
+        url: '/api/users/updateSubscriptions*'
+      },
+      { fixture: 'users/400.json' }
+    ).as('updateSubscriptions');
+
+    cy.visit('/users');
+
+    cy.get('[data-qa-update-subscriptions-input]').type('10');
+    cy.get('[data-qa-update-subscriptions-submit]').submit();
+
+    cy.wait('@updateSubscriptions');
+
+    cy.get('[data-qa-update-subscriptions-response]').contains(
+      JSON.stringify({
+        msg: 'No API key found on request',
+        code: 'BadApiKey',
+        params: { ip: '68.111.205.112', endpoint: '/api/users/update' }
+      })
+    );
+  });
+});


### PR DESCRIPTION
## JIRA Ticket(s) if any

* [MOB-3930](https://iterable.atlassian.net/browse/MOB-3930)

## Description

Adds cypress suite for Users page in React example app

## Test Steps

1. Run `yarn install:all && cd ./react-example && yarn cypress`
2. Run entire cypress suite in the pop-up window
3. Ensure all test pass