### PR TITLE
Add More Display Options to getMessages 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ log
 *.log
 results
 browserstack.json
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -598,7 +598,7 @@ import { baseAxiosRequest } from '@iterable/web-sdk/dist/request';
 
 ## I want to automatically show my in-app messages with a delay between each
 
-This SDK allows that. Simply call the `getMessages` method but pass `{ display: 'immeidate' }` as the second parameter. This will expose some methods used to make the request to show the messages and pause and resume the queue.
+This SDK allows that. Simply call the `getMessages` method but pass `{ display: 'immediate' }` as the second parameter. This will expose some methods used to make the request to show the messages and pause and resume the queue.
 
 Normally to request a list of in-app messages, you'd make a request like this:
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Below are the methods this SDK exposes. See [Iterable's API Docs](https://api.it
 
 | Method Name           	| Description                                                                                                               	|
 |-----------------------	|---------------------------------------------------------------------------------------------------------------------------	|
-| [`getInAppMessages`](#getInAppMessages)    	| Either return in-app messages as a Promise or automatically paint them to the DOM if the second argument is passed `true` 	|
+| [`getInAppMessages`](#getInAppMessages)    	| Either return in-app messages as a Promise or automatically paint them to the DOM if the second argument is passed `DisplayOptions` 	|
 | [`initialize`](#initialize)        	| Method for identifying users and setting a JWT                                                                            	|
 | [`track`](#track)               	| Track custom events                                                                                                       	|
 | [`trackInAppClick`](#trackInAppClick)     	| Track when a user clicks on a button or link within a message                                                             	|
@@ -135,7 +135,7 @@ const {
       topOffset: '20px'
     }
   },
-  true
+  { display: 'immediate' }
 );
 
 request()
@@ -598,7 +598,7 @@ import { baseAxiosRequest } from '@iterable/web-sdk/dist/request';
 
 ## I want to automatically show my in-app messages with a delay between each
 
-This SDK allows that. Simply call the `getMessages` method but pass `true` as the second parameter. This will expose some methods used to make the request to show the messages and pause and resume the queue.
+This SDK allows that. Simply call the `getMessages` method but pass `{ display: 'immeidate' }` as the second parameter. This will expose some methods used to make the request to show the messages and pause and resume the queue.
 
 Normally to request a list of in-app messages, you'd make a request like this:
 
@@ -648,7 +648,7 @@ import { getInAppMessages } from '@iterable/web-sdk/dist/inapp';
               count: 20,
               packageName: 'my-website'
             },
-            true
+            { display: 'immediate' }
           );
 
           /* trigger the start of message presentation */
@@ -690,7 +690,7 @@ import { getInAppMessages } from '@iterable/web-sdk/dist/inapp';
               animationDuration: 400,
               handleLinks: 'external-new-tab'
             },
-            true
+            { display: 'immediate' }
           );
 
           /* trigger the start of message presentation */
@@ -727,7 +727,7 @@ import { getInAppMessages } from '@iterable/web-sdk/dist/inapp';
               count: 20,
               packageName: 'my-website'
             },
-            true
+            { display: 'immediate' }
           );
 
           /* trigger the start of message presentation */

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Below are the methods this SDK exposes. See [Iterable's API Docs](https://api.it
 | [`updateCart`](#updateCart)          	| Update _shoppingCartItems_ field on user profile                                                                          	|
 | [`updateSubscriptions`](#updateSubscriptions) 	| Updates user's subscriptions                                                                                              	|
 | [`updateUser`](#updateUser)          	| Change data on a user's profile or create a user if none exists                                                           	|
-| [`updateUserEmail`](#updateUserEmail)     	| Change a user's email address                                                                                             	|
+| [`updateUserEmail`](#updateUserEmail)     	| Change a user's email and reauthenticate user with the new email address (in other words, we will call `setEmail` for you)                                                                                             	|
 
 # Usage
 
@@ -69,7 +69,7 @@ Below are the methods this SDK exposes. See [Iterable's API Docs](https://api.it
 API [(see required API payload here)](https://api.iterable.com/api/docs#In-app_getMessages):
 
 ```ts
-getInAppMessages: (payload: InAppMessagesRequestParams, showMessagesAutomatically?: boolean) => Promise<TrackConsumeData> | PaintInAppMessageData
+getInAppMessages: (payload: InAppMessagesRequestParams, showMessagesAutomatically?: boolean | { display: 'deferred' | 'immediate' }) => Promise<TrackConsumeData> | PaintInAppMessageData
 ```
 
 SDK Specific Options:
@@ -112,7 +112,7 @@ getInAppMessages({
   .catch()
 ```
 
-or
+or if you want to show messages automatically
 
 ```ts
 import { getInAppMessages } from '@iterable/web-sdk/dist/inapp';
@@ -143,6 +143,57 @@ request()
   .catch();
 ```
 
+or if you want to show messages with your own custom filtering/sorting and choose to display later:
+
+```ts
+import { 
+  getInAppMessages,
+  sortInAppMessages,
+  filterHiddenInAppMessages
+} from '@iterable/web-sdk/dist/inapp';
+
+const { 
+  request,
+  pauseMessageStream, 
+  resumeMessageStream,
+  triggerDisplayMessages
+} = getInAppMessages(
+  { 
+    count: 20,
+    packageName: 'my-website',
+    displayInterval: 5000,
+    onOpenScreenReaderMessage:
+      'hey screen reader here telling you something just popped up on your screen!',
+    onOpenNodeToTakeFocus: 'input',
+    closeButton: {
+      color: 'red',
+      size: '16px',
+      topOffset: '20px'
+    }
+  },
+  { display: 'deferred' }
+);
+
+request()
+  .then(response => {
+    /* do your own manipulation here */
+    const filteredMessages = doStuffToMessages(response.data.inAppMessages);
+
+    /* also feel free to take advantage of the sorting/filtering methods we use internally */
+    const furtherManipulatedMessages = sortInAppMessages(
+      filterHiddenInAppMessages(response.data.inAppMessages)
+    ) as InAppMessage[];
+
+    /* then display them whenever you want */
+    triggerDisplayMessages(furtherManipulatedMessages)
+  })
+  .catch();
+```
+
+:rotating_light: *PLEASE NOTE*: If you choose the `deferred` option, we will _not_ do any filtering or sorting on the messages internally. You will get the messages exactly as they come down from the API, untouched. This means you may (for example) show in-app messages marked `read` or show the messages in the wrong order based on `priority`.
+
+If you want to keep the default sorting and filtering, please take advantage of the `sortInAppMessages` and `filterHiddenInAppMessages` methods we provide.
+
 ## initialize
 
 API:
@@ -169,6 +220,24 @@ const { clearRefresh, setEmail, setUserID, logout } = initialize(
   */
   ({ email, userID }) => yourAsyncJWTGeneratorMethod({ email, userID }).then(({ jwt_token }) => jwt_token)
 )
+```
+
+:rotating_light: *PLEASE NOTE*: When you call `updateUserEmail`, we will invoke `yourAsyncJWTGenerationMethod` with the new email address even if you originally authenticated with a user ID, so if you chose to first call `setUserID`, you will need to ensure your backend can also handle JWT generation with email addresses. In other words, you need to make sure both invocations of your async JWT generation method work:
+
+```ts
+/* 
+  the key "email" can be whatever. You just need to make sure your method can be passed an
+  email somehow when originally calling "initialize"
+*/
+yourAsyncJWTGenerationMethod({ email: 'email@email.com' })
+```
+
+```ts
+/* 
+  the key "userID" can be whatever. You just need to make sure your method can be passed a
+  user ID somehow when originally calling "initialize"
+*/
+yourAsyncJWTGenerationMethod({ userID: '1sfds32' })
 ```
 
 ## track
@@ -678,6 +747,64 @@ import { getInAppMessages } from '@iterable/web-sdk/dist/inapp';
     })
 })();
 ```
+
+Finally, you can also choose to do your own manipulation to the messages before choosing to display them:
+
+```ts
+import { initialize } from '@iterable/web-sdk/dist/authorization';
+import { 
+  getInAppMessages,
+  sortInAppMessages,
+  filterHiddenInAppMessages
+} from '@iterable/web-sdk/dist/inapp';
+
+(() => {
+  const { setUserID } = initialize(
+    'YOUR_API_KEY_HERE',
+    ({ email, userID }) => yourAsyncJWTGeneratorMethod(({ email, userID })).then(({ jwt_token }) => jwt_token)
+  );
+
+  yourAsyncLoginMethod()
+    .then(response => {
+      setUserID(response.user_id)
+        .then(() => {
+          const { 
+            request,
+            pauseMessageStream, 
+            resumeMessageStream
+           } = getInAppMessages(
+            { 
+              count: 20,
+              packageName: 'my-website'
+            },
+            { display: 'deferred' }
+          );
+
+          /* trigger the start of message presentation */
+          request()
+            .then(response => {
+              /* do your own manipulation here */
+              const filteredMessages = doStuffToMessages(response.data.inAppMessages);
+
+              /* 
+                also feel free to take advantage of the sorting/filtering 
+                methods we use internally 
+              */
+              const furtherManipulatedMessages = sortInAppMessages(
+                filterHiddenInAppMessages(response.data.inAppMessages)
+              ) as InAppMessage[];
+
+              /* then display them whenever you want */
+              triggerDisplayMessages(furtherManipulatedMessages)
+            })
+            .catch();
+        })
+    })
+})();
+```
+
+:t
+
 
 ## I want my messages to look good on every device and be responsive
 

--- a/README.md
+++ b/README.md
@@ -803,9 +803,6 @@ import {
 })();
 ```
 
-:t
-
-
 ## I want my messages to look good on every device and be responsive
 
 This SDK already handles that for you. The rules for the in-app message presentation varies based on which display type you've selected. Here's a table to explain how it works:

--- a/example/src/index.ts
+++ b/example/src/index.ts
@@ -31,7 +31,12 @@ import {
     }
   );
 
-  const { request, pauseMessageStream, resumeMessageStream } = getInAppMessages(
+  const {
+    request,
+    pauseMessageStream,
+    resumeMessageStream,
+    triggerDisplayMessages
+  } = getInAppMessages(
     {
       count: 20,
       displayInterval: 1000,
@@ -52,7 +57,7 @@ import {
         // topOffset: '6%'
       }
     },
-    true
+    { display: 'deferred' }
   );
 
   const startBtn = document.getElementById('start');
@@ -68,6 +73,7 @@ import {
       startBtn.className = 'disabled';
       request()
         .then((response) => {
+          triggerDisplayMessages(response.data.inAppMessages);
           startBtn.innerText = `${response.data.inAppMessages.length} total messages retrieved!`;
         })
         .catch(console.warn);

--- a/src/inapp/index.ts
+++ b/src/inapp/index.ts
@@ -1,2 +1,3 @@
 export * from './inapp';
 export * from './types';
+export { filterHiddenInAppMessages, sortInAppMessages } from './utils';

--- a/src/inapp/tests/inapp.test.ts
+++ b/src/inapp/tests/inapp.test.ts
@@ -42,6 +42,13 @@ describe('getInAppMessages', () => {
       // expect(response.config.headers['SDK-Platform']).toBe(WEB_PLATFORM);
     });
 
+    it('should not paint an iframe to the DOM', async () => {
+      await getInAppMessages({ count: 10, packageName: 'my-lil-website' });
+
+      const element = document.getElementById('iterable-iframe');
+      expect(element?.tagName).toBeUndefined();
+    });
+
     it('should reject if fails client-side validation', async () => {
       try {
         await getInAppMessages({} as any);
@@ -165,10 +172,56 @@ describe('getInAppMessages', () => {
       expect(response.config.params.userId).toBeUndefined();
     });
 
-    it('should paint an iframe to the DOM', async () => {
+    it('should paint an iframe to the DOM if second argument is true', async () => {
       const { request } = getInAppMessages(
         { count: 10, packageName: 'my-lil-website' },
         true
+      );
+      await request();
+
+      const element = document.getElementById('iterable-iframe');
+      expect(element?.tagName).toBe('IFRAME');
+    });
+
+    it('should paint an iframe to the DOM if second argument is { display: "immediate" }', async () => {
+      const { request } = getInAppMessages(
+        { count: 10, packageName: 'my-lil-website' },
+        { display: 'immediate' }
+      );
+      await request();
+
+      const element = document.getElementById('iterable-iframe');
+      expect(element?.tagName).toBe('IFRAME');
+    });
+
+    it('should not paint an iframe to the DOM if second argument is { display: "deferred" }', async () => {
+      const { request } = getInAppMessages(
+        { count: 10, packageName: 'my-lil-website' },
+        { display: 'deferred' }
+      );
+      await request();
+
+      const element = document.getElementById('iterable-iframe');
+      expect(element?.tagName).toBeUndefined();
+    });
+
+    it('should paint an iframe to the DOM if second argument is { display: "deferred" } and display fn is called', async () => {
+      const { request, triggerDisplayMessages } = getInAppMessages(
+        { count: 10, packageName: 'my-lil-website' },
+        { display: 'deferred' }
+      );
+      await request().then((response) =>
+        triggerDisplayMessages(response.data.inAppMessages)
+      );
+
+      const element = document.getElementById('iterable-iframe');
+      expect(element?.tagName).toBe('IFRAME');
+    });
+
+    it('should paint an iframe to the DOM if second argument is { display: "nonsense" }', async () => {
+      const { request } = getInAppMessages(
+        { count: 10, packageName: 'my-lil-website' },
+        { display: 'nonsense' as any }
       );
       await request();
 


### PR DESCRIPTION
## JIRA Ticket(s) if any

* [MOB-4296](https://iterable.atlassian.net/browse/MOB-4296)

## Description

Updates `getMessages` API to allow for deferring the display of in-app messages to any time the user wants. API looks like this:

```ts
const { request, triggerDisplayMessages } = getMessages(...options, { display: 'deferred' })

request().then(response => triggerDisplayMessages(response.data.inAppMessages))
```

## Test Steps

1. Run a local JWT generation backend by [cloning this repo](https://github.com/Iterable/jwt-generator) and running `docker-compose up -d`
2. Run example app in this repo with `yarn install:all && yarn start:all`
3. Open up `localhost:8080` in your browser and login
    * change you email in the codebase by replacing `iterable.tester@gmail.com` with your email
4. In `src/example/index.ts` change `getMessages` call to these variants:

```ts
/* should not display any messages */
getMesssages(...options).then(response => response)
```

```ts
const { request } = getMesssages(...options, true)

/* ...etc */

/* should display messages immediately */
request()
```

```ts
const { request } = getMesssages(...options, { display: 'immediate' })

/* ...etc */

/* should display messages immediately */
request()
```

```ts
const { request, triggerDisplayMessages } = getMesssages(...options, { display: 'deferred' })

/* ...etc */

request().then(response => {
   /* should only display messages when _triggerDisplayMessages_ is called */
  triggerDisplayMessages(response.data.inAppMessages)
})
```