### PR TITLE
Prevent JS From Running in In-App Messages IFrame

### DIFF
--- a/src/inapp/utils.ts
+++ b/src/inapp/utils.ts
@@ -251,6 +251,7 @@ export const paintIFrame = (
   new Promise((resolve: (value: HTMLIFrameElement) => void) => {
     const iframe = document.createElement('iframe');
     iframe.setAttribute('id', 'iterable-iframe');
+    iframe.setAttribute('sandbox', 'allow-same-origin');
     /* 
       _display: none_ would remove the ability to set event handlers on elements
       so instead we choose to hide it visibly with CSS but not actually remove

--- a/src/inapp/utils.ts
+++ b/src/inapp/utils.ts
@@ -235,8 +235,13 @@ const mediaQueryXl = global?.matchMedia?.('(min-width: 1301px)');
 /**
  *
  * @param html html you want to paint to the DOM inside the iframe
- * @param callback method to run after HTML has been written to iframe
+ * @param position screen position the message should appear in
+ * @param shouldAnimate if the in-app should animate in/out
  * @param srMessage The message you want the screen reader to read when popping up the message
+ * @param topOffset how many px or % buffer between the in-app message and the top of the screen
+ * @param bottomOffset how many px or % buffer between the in-app message and the bottom of the screen
+ * @param rightOffset how many px or % buffer between the in-app message and the right of the screen
+ *
  * @returns { HTMLIFrameElement }
  */
 export const paintIFrame = (


### PR DESCRIPTION
## JIRA Ticket(s) if any

* [MOB-4483](https://iterable.atlassian.net/browse/MOB-4483)

## Description

Adds `sandbox` property to iframe for in-app messages to prevent JS from executing

## Test Steps

1. No real way to test this since there isn't a way for customers to get JS into their in-apps
   * so just confirm the messages appear as normal
   * Run a local JWT generation backend by [cloning this repo](https://github.com/Iterable/jwt-generator) and running `docker-compose up -d`
   * Run example app in this repo with `yarn install:all && yarn start:all:react`
   * Open up `localhost:8080` in your browser and login