### PR TITLE
Check for Pause before Invoking resumeMessageStream

### DIFF
--- a/react-example/src/views/InApp.tsx
+++ b/react-example/src/views/InApp.tsx
@@ -33,7 +33,7 @@ const { request, pauseMessageStream, resumeMessageStream } = getInAppMessages(
     count: 20,
     packageName: 'my-website',
     closeButton: {},
-    displayInterval: 2000
+    displayInterval: 10000
   },
   { display: 'immediate' }
 );

--- a/src/inapp/inapp.ts
+++ b/src/inapp/inapp.ts
@@ -597,6 +597,7 @@ export function getInAppMessages(
       },
       resumeMessageStream: () => {
         if (isPaused) {
+          isPaused = false;
           return paintMessageToDOM();
         }
       },

--- a/src/inapp/inapp.ts
+++ b/src/inapp/inapp.ts
@@ -37,10 +37,12 @@ import schema from './inapp.schema';
 let parsedMessages: InAppMessage[] = [];
 let timer: NodeJS.Timeout | null = null;
 let messageIndex = 0;
+let isPaused = false;
 
 export const clearMessages = () => {
   parsedMessages = [];
   messageIndex = 0;
+  isPaused = false;
   if (timer) {
     clearTimeout(timer);
   }
@@ -589,11 +591,14 @@ export function getInAppMessages(
           }),
       pauseMessageStream: () => {
         if (timer) {
+          isPaused = true;
           clearTimeout(timer);
         }
       },
       resumeMessageStream: () => {
-        return paintMessageToDOM();
+        if (isPaused) {
+          return paintMessageToDOM();
+        }
       },
       ...maybeDisplayFn
     };


### PR DESCRIPTION
## JIRA Ticket(s) if any

* [MOB-3948](https://iterable.atlassian.net/browse/MOB-3948)

## Description

Adds a check to `resumeMessageStream` to first check to see if the in-app message presentation is paused.

Fixes issue where:

1. Customer code calls `getInAppMessages()` to display messages
2. Customer code then calls `resumeMessageStream` before first calling `pauseMessageStream`
3. Another in-app will appear on top of the previous one.

## Test Steps

1. Run a local JWT generation backend by [cloning this repo](https://github.com/Iterable/jwt-generator) and running `docker-compose up -d`
2. Run example app in this repo with `yarn install:all && yarn start:all:react`
3. Open up `localhost:8080` in your browser and login with an email
4. Send yourself some in-app messages from Iterable app
5. Navigate to /inApp route and click "get messages (auto display)"
6. Close the first in-app and click "resume message stream"
   * you will have to remove the `disabled` property from the button in `react-example/src/views/InApp.tsx` to be able to click it
7. Ensure the next in-app does not appear
8. Click "pause message stream" then "resume message stream"
9. Ensure the next in-app message appears