### PR TITLE
[MOB-4576] Secure unprotected raw html path with iframe

### DIFF
--- a/src/inapp/inapp.ts
+++ b/src/inapp/inapp.ts
@@ -1,4 +1,5 @@
 import { throttle } from 'throttle-debounce';
+import set from 'lodash/set';
 import {
   InAppMessage,
   InAppMessagesRequestParams,
@@ -15,7 +16,8 @@ import {
   paintIFrame,
   paintOverlay,
   sortInAppMessages,
-  trackMessagesDelivered
+  trackMessagesDelivered,
+  wrapWithIFrame
 } from './utils';
 import {
   trackInAppClick,
@@ -625,6 +627,19 @@ export function getInAppMessages(
       response.data.inAppMessages || [],
       dupedPayload.packageName
     );
-    return response;
+    const messages = response.data.inAppMessages;
+    const withIframes = messages?.map((message) => {
+      const html = message.content?.html;
+      return html
+        ? set(message, 'content.html', wrapWithIFrame(html))
+        : message;
+    });
+    return {
+      ...response,
+      data: {
+        ...response.data,
+        inAppMessages: withIframes
+      }
+    };
   });
 }

--- a/src/inapp/inapp.ts
+++ b/src/inapp/inapp.ts
@@ -162,7 +162,7 @@ export function getInAppMessages(
 
         /* add the message's html to an iframe and paint it to the DOM */
         return paintIFrame(
-          activeMessage.content.html,
+          activeMessage.content.html as string,
           position,
           shouldAnimate,
           payload.onOpenScreenReaderMessage || 'in-app iframe message opened',
@@ -631,7 +631,7 @@ export function getInAppMessages(
     const withIframes = messages?.map((message) => {
       const html = message.content?.html;
       return html
-        ? set(message, 'content.html', wrapWithIFrame(html))
+        ? set(message, 'content.html', wrapWithIFrame(html as string))
         : message;
     });
     return {

--- a/src/inapp/tests/inapp.test.ts
+++ b/src/inapp/tests/inapp.test.ts
@@ -56,9 +56,7 @@ describe('getInAppMessages', () => {
       });
 
       response.data.inAppMessages.forEach((message) => {
-        expect(message.content?.html).toContain('iframe');
-        expect(message.content?.html).toContain('onload');
-        expect(message.content?.html).toContain('sandbox');
+        expect(message.content?.html).toBeInstanceOf(HTMLIFrameElement);
       });
     });
 

--- a/src/inapp/tests/inapp.test.ts
+++ b/src/inapp/tests/inapp.test.ts
@@ -49,6 +49,19 @@ describe('getInAppMessages', () => {
       expect(element?.tagName).toBeUndefined();
     });
 
+    it('should wrap each message in an iframe', async () => {
+      const response = await getInAppMessages({
+        count: 10,
+        packageName: 'my-lil-website'
+      });
+
+      response.data.inAppMessages.forEach((message) => {
+        expect(message.content?.html).toContain('iframe');
+        expect(message.content?.html).toContain('onload');
+        expect(message.content?.html).toContain('sandbox');
+      });
+    });
+
     it('should reject if fails client-side validation', async () => {
       try {
         await getInAppMessages({} as any);

--- a/src/inapp/types.ts
+++ b/src/inapp/types.ts
@@ -49,7 +49,7 @@ export interface InAppMessage {
   expiresAt: number;
   content: {
     payload?: Record<string, any>;
-    html: string;
+    html: string | HTMLIFrameElement;
     inAppDisplaySettings: {
       top: InAppDisplaySetting;
       right: InAppDisplaySetting;

--- a/src/inapp/utils.ts
+++ b/src/inapp/utils.ts
@@ -239,7 +239,7 @@ const mediaQueryXl = global?.matchMedia?.('(min-width: 1301px)');
 const generateSecuredIFrame = () => {
   const iframe = document.createElement('iframe');
   iframe.setAttribute('id', 'iterable-iframe');
-  iframe.setAttribute('sandbox', 'allow-same-origin');
+  iframe.setAttribute('sandbox', 'allow-same-origin allow-popups');
   /*
     _display: none_ would remove the ability to set event handlers on elements
     so instead we choose to hide it visibly with CSS but not actually remove

--- a/src/inapp/utils.ts
+++ b/src/inapp/utils.ts
@@ -239,7 +239,12 @@ const mediaQueryXl = global?.matchMedia?.('(min-width: 1301px)');
 const generateSecuredIFrame = () => {
   const iframe = document.createElement('iframe');
   iframe.setAttribute('id', 'iterable-iframe');
-  iframe.setAttribute('sandbox', 'allow-same-origin allow-popups');
+  // allow-popups and allow-top-navigation is to enable links for Safari since the iframe will block
+  // event handlers on elements in it preventing our custom link handling
+  iframe.setAttribute(
+    'sandbox',
+    'allow-same-origin allow-popups allow-top-navigation'
+  );
   /*
     _display: none_ would remove the ability to set event handlers on elements
     so instead we choose to hide it visibly with CSS but not actually remove
@@ -262,16 +267,16 @@ const generateSecuredIFrame = () => {
 /**
  *
  * @param html
- * @returns { string } html string of an inapp message to wrap in an iframe for render
+ * @returns { HTMLIFrameElement } iframe with html string of an inapp message wrapped in onload
  */
-export const wrapWithIFrame = (html: string): string => {
+export const wrapWithIFrame = (html: string): HTMLIFrameElement => {
   const iframe = generateSecuredIFrame();
-  return iframe.outerHTML.replace(
-    '<iframe',
-    `<iframe onload='((f) => {const doc = "${html
-      .replaceAll(/\r?\n|\r/g, '')
-      .replaceAll('"', '\\"')}";f.contentWindow.document.write(doc);})(this)'`
-  );
+  iframe.onload = () => {
+    iframe.contentWindow?.document.write(
+      html.replaceAll(/\r?\n|\r/g, '').replaceAll('"', '\\"')
+    );
+  };
+  return iframe;
 };
 
 /**

--- a/src/inapp/utils.ts
+++ b/src/inapp/utils.ts
@@ -272,9 +272,7 @@ const generateSecuredIFrame = () => {
 export const wrapWithIFrame = (html: string): HTMLIFrameElement => {
   const iframe = generateSecuredIFrame();
   iframe.onload = () => {
-    iframe.contentWindow?.document.write(
-      html.replaceAll(/\r?\n|\r/g, '').replaceAll('"', '\\"')
-    );
+    iframe.contentWindow?.document.write(html);
   };
   return iframe;
 };

--- a/src/inapp/utils.ts
+++ b/src/inapp/utils.ts
@@ -234,6 +234,48 @@ const mediaQueryXl = global?.matchMedia?.('(min-width: 1301px)');
 
 /**
  *
+ * @returns { HTMLIFrameElement } iframe with sandbox and hidden styling applied for of an inapp message to render with
+ */
+const generateSecuredIFrame = () => {
+  const iframe = document.createElement('iframe');
+  iframe.setAttribute('id', 'iterable-iframe');
+  iframe.setAttribute('sandbox', 'allow-same-origin');
+  /*
+    _display: none_ would remove the ability to set event handlers on elements
+    so instead we choose to hide it visibly with CSS but not actually remove
+    its interact-ability
+
+    https://snook.ca/archives/html_and_css/hiding-content-for-accessibility
+  */
+  iframe.style.cssText = `
+    position: fixed !important;
+    top: 0;
+    left: 0;
+    height: 1px;
+    width: 1px;
+    overflow: hidden;
+  `;
+
+  return iframe;
+};
+
+/**
+ *
+ * @param html
+ * @returns { string } html string of an inapp message to wrap in an iframe for render
+ */
+export const wrapWithIFrame = (html: string): string => {
+  const iframe = generateSecuredIFrame();
+  return iframe.outerHTML.replace(
+    '<iframe',
+    `<iframe onload='((f) => {const doc = "${html
+      .replaceAll(/\r?\n|\r/g, '')
+      .replaceAll('"', '\\"')}";f.contentWindow.document.write(doc);})(this)'`
+  );
+};
+
+/**
+ *
  * @param html html you want to paint to the DOM inside the iframe
  * @param position screen position the message should appear in
  * @param shouldAnimate if the in-app should animate in/out
@@ -254,26 +296,7 @@ export const paintIFrame = (
   rightOffset?: string
 ): Promise<HTMLIFrameElement> =>
   new Promise((resolve: (value: HTMLIFrameElement) => void) => {
-    const iframe = document.createElement('iframe');
-    iframe.setAttribute('id', 'iterable-iframe');
-    iframe.setAttribute('sandbox', 'allow-same-origin');
-    /* 
-      _display: none_ would remove the ability to set event handlers on elements
-      so instead we choose to hide it visibly with CSS but not actually remove
-      its interact-ability
-      
-      https://snook.ca/archives/html_and_css/hiding-content-for-accessibility 
-    */
-    iframe.style.cssText = `
-      position: fixed !important;
-      top: 0;
-      left: 0;
-      height: 1px;
-      width: 1px;
-      overflow: hidden;
-      clip: rect(1px 1px 1px 1px);
-      clip: rect(1px, 1px, 1px, 1px);
-    `;
+    const iframe = generateSecuredIFrame();
 
     /* 
       find all the images in the in-app message, preload them, and 


### PR DESCRIPTION
## JIRA Ticket(s) if any

(https://iterable.atlassian.net/browse/MOB-4576)

## Description

- Updates `getInAppMessages` path when `showInAppMessagesAutomatically` is not passed in and wraps the inapp message HTML in the API response with an iframe to be securely rendered to prevent JS execution

## Test Steps

Run the example app and pull messages without showing messages automatically and see that the HTML returned is instead an iframe with the HTML content inside and a sandbox attribute