### PR TITLE
[MOB-4677] Prevent dismissing of in-app message when clicking outside of message

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,15 +90,15 @@ Along with the API parameters, you can pass these options to the SDK method to h
 
 Close Button Options:
 
-| Property Name            | Description                                                                                | Value                      | Default       |
-| ------------------------ | ------------------------------------------------------------------------------------------ | -------------------------- | ------------- |
-| color                    | What color the button is (does not affect custom icons)                                    | `string`                   | `undefined`   |
-| iconPath                 | Custom pathname to an image or SVG you want to show instead of the default "X"             | `string`                   | `undefined`   |
-| position                 | Where to appear relative to the in-app message                                             | `'top-right \| 'top-left'` | `'top-right'` |
-| requiredToDismissMessage | If set to true, prevent user from dismissing in-app message by clicking outside of message | `boolean`                  | `undefined`   |
-| sideOffset               | How much space to leave between the button and side of the container                       | `string`                   | `'4%'`        |
-| size                     | How large to set the width, height, and font-size                                          | `string \| number`         | `24`          |
-| topOffset                | How much space to leave between the button and the top of the container                    | `string`                   | `'4%'`        |
+| Property Name              | Description                                                                                | Value                      | Default       |
+| -------------------------- | ------------------------------------------------------------------------------------------ | -------------------------- | ------------- |
+| color                      | What color the button is (does not affect custom icons)                                    | `string`                   | `undefined`   |
+| iconPath                   | Custom pathname to an image or SVG you want to show instead of the default "X"             | `string`                   | `undefined`   |
+| position                   | Where to appear relative to the in-app message                                             | `'top-right \| 'top-left'` | `'top-right'` |
+| isRequiredToDismissMessage | If set to true, prevent user from dismissing in-app message by clicking outside of message | `boolean`                  | `undefined`   |
+| sideOffset                 | How much space to leave between the button and side of the container                       | `string`                   | `'4%'`        |
+| size                       | How large to set the width, height, and font-size                                          | `string \| number`         | `24`          |
+| topOffset                  | How much space to leave between the button and the top of the container                    | `string`                   | `'4%'`        |
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -90,14 +90,15 @@ Along with the API parameters, you can pass these options to the SDK method to h
 
 Close Button Options:
 
-| Property Name | Description                                                                    | Value                      | Default       |
-|---------------|--------------------------------------------------------------------------------|----------------------------|---------------|
-| color         | What color the button is (does not affect custom icons)                        | `string`                   | `undefined`   |
-| iconPath      | Custom pathname to an image or SVG you want to show instead of the default "X" | `string`                   | `undefined`   |
-| position      | Where to appear relative to the in-app message                                 | `'top-right \| 'top-left'` | `'top-right'` |
-| sideOffset    | How much space to leave between the button and side of the container           | `string`                   | `'4%'`        |
-| size          | How large to set the width, height, and font-size                              | `string \| number`         | `24`          |
-| topOffset     | How much space to leave between the button and the top of the container        | `string`                   | `'4%'`        |
+| Property Name            | Description                                                                                | Value                      | Default       |
+| ------------------------ | ------------------------------------------------------------------------------------------ | -------------------------- | ------------- |
+| color                    | What color the button is (does not affect custom icons)                                    | `string`                   | `undefined`   |
+| iconPath                 | Custom pathname to an image or SVG you want to show instead of the default "X"             | `string`                   | `undefined`   |
+| position                 | Where to appear relative to the in-app message                                             | `'top-right \| 'top-left'` | `'top-right'` |
+| requiredToDismissMessage | If set to true, prevent user from dismissing in-app message by clicking outside of message | `boolean`                  | `undefined`   |
+| sideOffset               | How much space to leave between the button and side of the container                       | `string`                   | `'4%'`        |
+| size                     | How large to set the width, height, and font-size                                          | `string \| number`         | `24`          |
+| topOffset                | How much space to leave between the button and the top of the container                    | `string`                   | `'4%'`        |
 
 Example:
 

--- a/src/inapp/inapp.ts
+++ b/src/inapp/inapp.ts
@@ -258,18 +258,20 @@ export function getInAppMessages(
             );
           }
 
-          overlay.addEventListener('click', () => {
-            dismissMessage(activeIframe);
-            overlay.remove();
-            document.removeEventListener('keydown', handleDocumentEscPress);
-            if (activeIframe?.contentWindow?.document) {
-              activeIframe.contentWindow?.document.removeEventListener(
-                'keydown',
-                handleIFrameEscPress
-              );
-            }
-            global.removeEventListener('resize', throttledResize);
-          });
+          if (!payload.closeButton?.requiredToDismissMessage) {
+            overlay.addEventListener('click', () => {
+              dismissMessage(activeIframe);
+              overlay.remove();
+              document.removeEventListener('keydown', handleDocumentEscPress);
+              if (activeIframe?.contentWindow?.document) {
+                activeIframe.contentWindow?.document.removeEventListener(
+                  'keydown',
+                  handleIFrameEscPress
+                );
+              }
+              global.removeEventListener('resize', throttledResize);
+            });
+          }
 
           /*
             create an absolutely positioned button that lies underneath the

--- a/src/inapp/inapp.ts
+++ b/src/inapp/inapp.ts
@@ -258,7 +258,7 @@ export function getInAppMessages(
             );
           }
 
-          if (!payload.closeButton?.requiredToDismissMessage) {
+          if (!payload.closeButton?.isRequiredToDismissMessage) {
             overlay.addEventListener('click', () => {
               dismissMessage(activeIframe);
               overlay.remove();

--- a/src/inapp/types.ts
+++ b/src/inapp/types.ts
@@ -15,7 +15,7 @@ interface SDKInAppMessagesParams {
     iconPath?: string;
     position?: 'top-left' | 'top-right';
     /* If set to true, prevent user from dismissing in-app message by clicking outside of message */
-    requiredToDismissMessage?: boolean;
+    isRequiredToDismissMessage?: boolean;
     sideOffset?: string;
     size?: string | number;
     topOffset?: string;

--- a/src/inapp/types.ts
+++ b/src/inapp/types.ts
@@ -14,6 +14,8 @@ interface SDKInAppMessagesParams {
     color?: string;
     iconPath?: string;
     position?: 'top-left' | 'top-right';
+    /* If set to true, prevent user from dismissing in-app message by clicking outside of message */
+    requiredToDismissMessage?: boolean;
     sideOffset?: string;
     size?: string | number;
     topOffset?: string;

--- a/src/inapp/utils.ts
+++ b/src/inapp/utils.ts
@@ -256,7 +256,10 @@ export const paintIFrame = (
   new Promise((resolve: (value: HTMLIFrameElement) => void) => {
     const iframe = document.createElement('iframe');
     iframe.setAttribute('id', 'iterable-iframe');
-    iframe.setAttribute('sandbox', 'allow-same-origin');
+    iframe.setAttribute(
+      'sandbox',
+      'allow-same-origin allow-popups allow-top-navigation'
+    );
     /* 
       _display: none_ would remove the ability to set event handlers on elements
       so instead we choose to hide it visibly with CSS but not actually remove

--- a/src/inapp/utils.ts
+++ b/src/inapp/utils.ts
@@ -256,10 +256,7 @@ export const paintIFrame = (
   new Promise((resolve: (value: HTMLIFrameElement) => void) => {
     const iframe = document.createElement('iframe');
     iframe.setAttribute('id', 'iterable-iframe');
-    iframe.setAttribute(
-      'sandbox',
-      'allow-same-origin allow-popups allow-top-navigation'
-    );
+    iframe.setAttribute('sandbox', 'allow-same-origin');
     /* 
       _display: none_ would remove the ability to set event handlers on elements
       so instead we choose to hide it visibly with CSS but not actually remove


### PR DESCRIPTION
## JIRA Ticket(s) if any

* [MOB-4677](https://iterable.atlassian.net/browse/MOB-4677)

## Description

Adds an optional configuration property in getInAppMessages payload under the `closeButton` configuration.

```ts
closeButton?: {
  ...
  isRequiredToDismissMessage?: boolean;
  ...
}
```

## Test Steps

1. Set `requiredToDismissMessage: true` in getInAppMessages payload
2. Start up the react-example app
3. Login
4. Click InApp
5. Fetch in-app messages
6. Click outside the message -> Expected behavior: Message does NOT close
7. Click on close button -> Expected behavior: Message closes