### PR TITLE
[MOB-4740] Filter out messages set to deliver silently

### DIFF
--- a/src/inapp/inapp.ts
+++ b/src/inapp/inapp.ts
@@ -354,6 +354,7 @@ export function getInAppMessages(
           */
           if (ENABLE_INAPP_CONSUME || IS_PRODUCTION) {
             const trackRequests = [
+              // TODO: Backend is not setting message to read
               trackInAppOpen({
                 messageId: activeMessage.messageId,
                 deviceInfo: {
@@ -361,7 +362,7 @@ export function getInAppMessages(
                 }
               })
             ];
-            if (activeMessage.trigger.type !== 'never')
+            if (!activeMessage?.saveToInbox)
               trackRequests.push(
                 trackInAppConsume({
                   messageId: activeMessage.messageId,

--- a/src/inapp/inapp.ts
+++ b/src/inapp/inapp.ts
@@ -348,7 +348,7 @@ export function getInAppMessages(
 
           /* 
             track in-app consumes only when _trigger.type_ 
-            is NOT never or undefined and always track in-app opens
+            is NOT "never" or undefined and always track in-app opens
 
             Also swallow any 400+ response errors. We don't care about them.
           */
@@ -566,7 +566,7 @@ export function getInAppMessages(
               if the user passed the flag to automatically paint the in-app messages
               to the DOM, start a timer and show each in-app message upon close + timer countdown
               
-              However there are 4 conditions in which to not show a message:
+              However there are 3 conditions in which to not show a message:
               
               1. _read_ key is truthy
               2. _trigger.type_ key is "never" (deliver silently is checked)

--- a/src/inapp/inapp.ts
+++ b/src/inapp/inapp.ts
@@ -347,14 +347,13 @@ export function getInAppMessages(
           }
 
           /* 
-            track in-app consumes only when _trigger.type_ 
-            is NOT "never" or undefined and always track in-app opens
+            track in-app consumes only when _saveToInbox_ 
+            is falsy or undefined and always track in-app opens
 
             Also swallow any 400+ response errors. We don't care about them.
           */
           if (ENABLE_INAPP_CONSUME || IS_PRODUCTION) {
             const trackRequests = [
-              // TODO: Backend is not setting message to read
               trackInAppOpen({
                 messageId: activeMessage.messageId,
                 deviceInfo: {
@@ -362,7 +361,7 @@ export function getInAppMessages(
                 }
               })
             ];
-            if (!activeMessage?.saveToInbox)
+            if (!activeMessage.saveToInbox)
               trackRequests.push(
                 trackInAppConsume({
                   messageId: activeMessage.messageId,


### PR DESCRIPTION
## JIRA Ticket(s) if any

* [MOB-4740](https://iterable.atlassian.net/browse/MOB-4740)

## Description

Messages that are delivered silently or read should not be displayed by the SDK. Filters out messages that have trigger.type set to 'never' so that these messages never get painted to the DOM.

## Test Steps

### Scenario 1
1. Send yourself an in-app message proof with inbox off and deliver silently off
2. Start example app and paint messages
3. Expected: Message displays on screen

### Scenario 2
1. Send yourself an in-app message proof with inbox on and deliver silently off
2. Start example app and paint messages
3. Expected: Message displays on screen

### Scenario 3
1. Send yourself an in-app message proof with inbox on and deliver silently on
2. Start example app and paint messages
3. Expected: Message does NOT display on screen

### Scenario 4
1. Set up an in-app message with inbox on and deliver silently on
2. Save template
3. Turn inbox off (do not touch deliver silently checkbox)
4. Save template
5. Send yourself a proof
6. Start example app and paint messages
7. Expected: Message displays on screen