### PR TITLE
[MOB-4840] Fix iframe height setting

### DIFF
--- a/src/inapp/utils.ts
+++ b/src/inapp/utils.ts
@@ -423,8 +423,10 @@ export const paintIFrame = (
         };
 
         if (position !== 'Full') {
+          const iframeHeight =
+            iframe.contentWindow?.document?.body?.scrollHeight;
           iframe.style.height =
-            (iframe.contentWindow?.document?.body?.scrollHeight || 0) + 'px';
+            ((iframeHeight && iframeHeight + 16) || 0) + 'px';
         }
 
         clearTimeout(timeout);

--- a/src/inapp/utils.ts
+++ b/src/inapp/utils.ts
@@ -425,6 +425,11 @@ export const paintIFrame = (
         if (position !== 'Full') {
           const iframeHeight =
             iframe.contentWindow?.document?.body?.scrollHeight;
+          /*
+            For web in-app messages created with WYSIWYG editor,
+            there is 8px margin all around the iframe document body.
+            Add 16px to the iframe height to eliminate scrollbar.
+          */
           iframe.style.height =
             ((iframeHeight && iframeHeight + 16) || 0) + 'px';
         }


### PR DESCRIPTION
## JIRA Ticket(s) if any

* [MOB-4840](https://iterable.atlassian.net/browse/MOB-4840)

## Description

The iframe document body has an 8px margin all around. The iframe height is set based on the body's scrollheight without taking the margin into consideration. Adds 16px to the iframe's scrollheight to eliminate the scrollbar that occurs when user uses the WYSIWYG editor to create their in-app.

## Test Steps

1. Create WYSIWYG in-app template
2. Send to yourself
3. Render in web sample app
4. No scrollbar