### PR TITLE
[MOB-4490] Deprecate boolean from getInAppMessages showInAppMessagesAutomatically param

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Close Button Options:
 
 Example:
 
-Calling `getInAppMessages` with `showInAppMessagesAutomatically` set to `false` (or not set) returns a JSON API response from Iterable. This response includes an `inAppMessages` field, and each item in the list has a `content.html` field that's an `iframe` with an embedded in-app message. The `iframe`'s `sandbox` attribute is set, isolating its render and preventing any malicious JavaScript execution.
+Calling `getInAppMessages` with `showInAppMessagesAutomatically` not set returns a JSON API response from Iterable. This response includes an `inAppMessages` field, and each item in the list has a `content.html` field that's an `iframe` with an embedded in-app message. The `iframe`'s `sandbox` attribute is set, isolating its render and preventing any malicious JavaScript execution.
 ```ts
 import { getInAppMessages } from '@iterable/web-sdk/dist/inapp';
 

--- a/react-example/src/views/InApp.tsx
+++ b/react-example/src/views/InApp.tsx
@@ -28,11 +28,6 @@ const AutoDisplayContainer = styled.div`
   }
 `;
 
-enum DISPLAY_OPTIONS {
-  immediate = 'immediate',
-  deferred = 'deferred'
-}
-
 const { request, pauseMessageStream, resumeMessageStream } = getInAppMessages(
   {
     count: 20,
@@ -40,7 +35,7 @@ const { request, pauseMessageStream, resumeMessageStream } = getInAppMessages(
     closeButton: {},
     displayInterval: 10000
   },
-  { display: DISPLAY_OPTIONS.immediate }
+  { display: 'immediate' }
 );
 
 export const InApp: FC<{}> = () => {

--- a/react-example/src/views/InApp.tsx
+++ b/react-example/src/views/InApp.tsx
@@ -28,6 +28,11 @@ const AutoDisplayContainer = styled.div`
   }
 `;
 
+enum DISPLAY_OPTIONS {
+  immediate = 'immediate',
+  deferred = 'deferred'
+}
+
 const { request, pauseMessageStream, resumeMessageStream } = getInAppMessages(
   {
     count: 20,
@@ -35,7 +40,7 @@ const { request, pauseMessageStream, resumeMessageStream } = getInAppMessages(
     closeButton: {},
     displayInterval: 10000
   },
-  { display: 'immediate' }
+  { display: DISPLAY_OPTIONS.immediate }
 );
 
 export const InApp: FC<{}> = () => {

--- a/src/inapp/inapp.ts
+++ b/src/inapp/inapp.ts
@@ -66,16 +66,14 @@ export function getInAppMessages(
 };
 export function getInAppMessages(
   payload: InAppMessagesRequestParams,
-  showInAppMessagesAutomatically?:
-    | boolean
-    | { display: 'immediate' | 'deferred' }
+  showInAppMessagesAutomatically?: { display: 'immediate' | 'deferred' }
 ) {
   clearMessages();
   const dupedPayload = { ...payload };
 
   /* delete SDK-defined payload props and email and userId */
-  delete (dupedPayload as any).userId;
-  delete (dupedPayload as any).email;
+  delete (dupedPayload as any).userId; // eslint-disable-line @typescript-eslint/no-explicit-any
+  delete (dupedPayload as any).email; // eslint-disable-line @typescript-eslint/no-explicit-any
   delete dupedPayload.displayInterval;
   delete dupedPayload.onOpenScreenReaderMessage;
   delete dupedPayload.onOpenNodeToTakeFocus;

--- a/src/inapp/inapp.ts
+++ b/src/inapp/inapp.ts
@@ -5,7 +5,7 @@ import {
   InAppMessage,
   InAppMessagesRequestParams,
   InAppMessageResponse,
-  DISPLAY_OPTIONS
+  DisplayOptions
 } from './types';
 import { IterablePromise } from '../types';
 import { baseIterableRequest } from '../request';
@@ -58,9 +58,7 @@ export function getInAppMessages(
 ): IterablePromise<InAppMessageResponse>;
 export function getInAppMessages(
   payload: InAppMessagesRequestParams,
-  showInAppMessagesAutomatically: {
-    display: DISPLAY_OPTIONS.immediate | DISPLAY_OPTIONS.deferred;
-  }
+  showInAppMessagesAutomatically: { display: DisplayOptions }
 ): {
   pauseMessageStream: () => void;
   resumeMessageStream: () => Promise<HTMLIFrameElement | ''>;
@@ -71,9 +69,7 @@ export function getInAppMessages(
 };
 export function getInAppMessages(
   payload: InAppMessagesRequestParams,
-  showInAppMessagesAutomatically?: {
-    display: DISPLAY_OPTIONS.immediate | DISPLAY_OPTIONS.deferred;
-  }
+  showInAppMessagesAutomatically?: { display: DisplayOptions }
 ) {
   clearMessages();
   const dupedPayload = { ...payload };

--- a/src/inapp/inapp.ts
+++ b/src/inapp/inapp.ts
@@ -3,7 +3,8 @@ import set from 'lodash/set';
 import {
   InAppMessage,
   InAppMessagesRequestParams,
-  InAppMessageResponse
+  InAppMessageResponse,
+  DISPLAY
 } from './types';
 import { IterablePromise } from '../types';
 import { baseIterableRequest } from '../request';
@@ -55,7 +56,9 @@ export function getInAppMessages(
 ): IterablePromise<InAppMessageResponse>;
 export function getInAppMessages(
   payload: InAppMessagesRequestParams,
-  showInAppMessagesAutomatically: { display: 'immediate' | 'deferred' }
+  showInAppMessagesAutomatically: {
+    display: DISPLAY.immediate | DISPLAY.deferred;
+  }
 ): {
   pauseMessageStream: () => void;
   resumeMessageStream: () => Promise<HTMLIFrameElement | ''>;
@@ -66,7 +69,9 @@ export function getInAppMessages(
 };
 export function getInAppMessages(
   payload: InAppMessagesRequestParams,
-  showInAppMessagesAutomatically?: { display: 'immediate' | 'deferred' }
+  showInAppMessagesAutomatically?: {
+    display: DISPLAY.immediate | DISPLAY.deferred;
+  }
 ) {
   clearMessages();
   const dupedPayload = { ...payload };

--- a/src/inapp/inapp.ts
+++ b/src/inapp/inapp.ts
@@ -72,8 +72,8 @@ export function getInAppMessages(
   const dupedPayload = { ...payload };
 
   /* delete SDK-defined payload props and email and userId */
-  delete (dupedPayload as any).userId; // eslint-disable-line @typescript-eslint/no-explicit-any
-  delete (dupedPayload as any).email; // eslint-disable-line @typescript-eslint/no-explicit-any
+  delete (dupedPayload as any).userId;
+  delete (dupedPayload as any).email;
   delete dupedPayload.displayInterval;
   delete dupedPayload.onOpenScreenReaderMessage;
   delete dupedPayload.onOpenNodeToTakeFocus;

--- a/src/inapp/inapp.ts
+++ b/src/inapp/inapp.ts
@@ -55,14 +55,6 @@ export function getInAppMessages(
 ): IterablePromise<InAppMessageResponse>;
 export function getInAppMessages(
   payload: InAppMessagesRequestParams,
-  showInAppMessagesAutomatically: true
-): {
-  pauseMessageStream: () => void;
-  resumeMessageStream: () => Promise<HTMLIFrameElement | ''>;
-  request: () => IterablePromise<InAppMessageResponse>;
-};
-export function getInAppMessages(
-  payload: InAppMessagesRequestParams,
   showInAppMessagesAutomatically: { display: 'immediate' | 'deferred' }
 ): {
   pauseMessageStream: () => void;
@@ -503,9 +495,7 @@ export function getInAppMessages(
       return Promise.resolve('');
     };
 
-    const isDeferred =
-      typeof showInAppMessagesAutomatically !== 'boolean' &&
-      showInAppMessagesAutomatically.display === 'deferred';
+    const isDeferred = showInAppMessagesAutomatically.display === 'deferred';
 
     const triggerDisplayFn = isDeferred
       ? {

--- a/src/inapp/inapp.ts
+++ b/src/inapp/inapp.ts
@@ -4,7 +4,7 @@ import {
   InAppMessage,
   InAppMessagesRequestParams,
   InAppMessageResponse,
-  DISPLAY
+  DISPLAY_OPTIONS
 } from './types';
 import { IterablePromise } from '../types';
 import { baseIterableRequest } from '../request';
@@ -57,7 +57,7 @@ export function getInAppMessages(
 export function getInAppMessages(
   payload: InAppMessagesRequestParams,
   showInAppMessagesAutomatically: {
-    display: DISPLAY.immediate | DISPLAY.deferred;
+    display: DISPLAY_OPTIONS.immediate | DISPLAY_OPTIONS.deferred;
   }
 ): {
   pauseMessageStream: () => void;
@@ -70,7 +70,7 @@ export function getInAppMessages(
 export function getInAppMessages(
   payload: InAppMessagesRequestParams,
   showInAppMessagesAutomatically?: {
-    display: DISPLAY.immediate | DISPLAY.deferred;
+    display: DISPLAY_OPTIONS.immediate | DISPLAY_OPTIONS.deferred;
   }
 ) {
   clearMessages();

--- a/src/inapp/inapp.ts
+++ b/src/inapp/inapp.ts
@@ -5,7 +5,8 @@ import {
   InAppMessage,
   InAppMessagesRequestParams,
   InAppMessageResponse,
-  DisplayOptions
+  DisplayOptions,
+  DISPLAY_OPTIONS
 } from './types';
 import { IterablePromise } from '../types';
 import { baseIterableRequest } from '../request';
@@ -577,7 +578,8 @@ export function getInAppMessages(
       return Promise.resolve('');
     };
 
-    const isDeferred = showInAppMessagesAutomatically.display === 'deferred';
+    const isDeferred =
+      showInAppMessagesAutomatically.display === DISPLAY_OPTIONS.deferred;
 
     const triggerDisplayFn = isDeferred
       ? {

--- a/src/inapp/tests/inapp.test.ts
+++ b/src/inapp/tests/inapp.test.ts
@@ -131,7 +131,7 @@ describe('getInAppMessages', () => {
     it('should send up correct payload', async () => {
       const response = await getInAppMessages(
         { count: 10, packageName: 'my-lil-website' },
-        true
+        { display: 'immediate' }
       ).request();
 
       expect(response.config.params.packageName).toBe('my-lil-website');
@@ -141,7 +141,7 @@ describe('getInAppMessages', () => {
 
     it('should reject if fails client-side validation', async () => {
       try {
-        await getInAppMessages({} as any, true).request();
+        await getInAppMessages({} as any, { display: 'immediate' }).request();
       } catch (e) {
         expect(e).toEqual(
           createClientError([
@@ -161,7 +161,7 @@ describe('getInAppMessages', () => {
     it('should return correct values when auto-paint flag is true', async () => {
       const response = await getInAppMessages(
         { count: 10, packageName: 'my-lil-website' },
-        true
+        { display: 'immediate' }
       );
       expect(response.pauseMessageStream).toBeDefined();
       expect(response.resumeMessageStream).toBeDefined();
@@ -176,22 +176,11 @@ describe('getInAppMessages', () => {
           count: 10,
           packageName: 'my-lil-website'
         } as any,
-        true
+        { display: 'immediate' }
       ).request();
 
       expect(response.config.params.email).toBeUndefined();
       expect(response.config.params.userId).toBeUndefined();
-    });
-
-    it('should paint an iframe to the DOM if second argument is true', async () => {
-      const { request } = getInAppMessages(
-        { count: 10, packageName: 'my-lil-website' },
-        true
-      );
-      await request();
-
-      const element = document.getElementById('iterable-iframe');
-      expect(element?.tagName).toBe('IFRAME');
     });
 
     it('should paint an iframe to the DOM if second argument is { display: "immediate" }', async () => {
@@ -243,7 +232,7 @@ describe('getInAppMessages', () => {
     it('should remove the iframe when dismiss link is clicked', async () => {
       const { request } = getInAppMessages(
         { count: 10, packageName: 'my-lil-website' },
-        true
+        { display: 'immediate' }
       );
       await request();
 
@@ -269,7 +258,7 @@ describe('getInAppMessages', () => {
     it('should remove the iframe when esc key is pressed within the iframe', async () => {
       const { request } = getInAppMessages(
         { count: 10, packageName: 'my-lil-website' },
-        true
+        { display: 'immediate' }
       );
       await request();
 
@@ -285,7 +274,7 @@ describe('getInAppMessages', () => {
     it('should remove the iframe when esc key is pressed within the document body', async () => {
       const { request } = getInAppMessages(
         { count: 10, packageName: 'my-lil-website' },
-        true
+        { display: 'immediate' }
       );
       await request();
 
@@ -300,7 +289,7 @@ describe('getInAppMessages', () => {
     it('should remove the iframe when overlay is clicked', async () => {
       const { request } = getInAppMessages(
         { count: 10, packageName: 'my-lil-website' },
-        true
+        { display: 'immediate' }
       );
       await request();
 
@@ -323,7 +312,7 @@ describe('getInAppMessages', () => {
           packageName: 'my-lil-website',
           closeButton: {}
         },
-        true
+        { display: 'immediate' }
       );
       await request();
 
@@ -346,7 +335,7 @@ describe('getInAppMessages', () => {
     it('should paint next message to the DOM after 30s after first is dismissed', async () => {
       const { request } = getInAppMessages(
         { count: 10, packageName: 'my-lil-website' },
-        true
+        { display: 'immediate' }
       );
       await request();
 
@@ -376,7 +365,7 @@ describe('getInAppMessages', () => {
     it('should not paint next message to the DOM after 30s if queue is paused', async () => {
       const { request, pauseMessageStream } = getInAppMessages(
         { count: 10, packageName: 'my-lil-website' },
-        true
+        { display: 'immediate' }
       );
       await request();
 
@@ -398,7 +387,10 @@ describe('getInAppMessages', () => {
 
     it('should paint next message to DOM if resumed', async () => {
       const { request, pauseMessageStream, resumeMessageStream } =
-        getInAppMessages({ count: 10, packageName: 'my-lil-website' }, true);
+        getInAppMessages(
+          { count: 10, packageName: 'my-lil-website' },
+          { display: 'immediate' }
+        );
       await request();
 
       const iframe = document.getElementById(
@@ -440,7 +432,7 @@ describe('getInAppMessages', () => {
 
       const { request } = getInAppMessages(
         { count: 10, packageName: 'my-lil-website' },
-        true
+        { display: 'immediate' }
       );
       await request();
 
@@ -484,7 +476,7 @@ describe('getInAppMessages', () => {
 
       const { request } = getInAppMessages(
         { count: 10, packageName: 'my-lil-website' },
-        true
+        { display: 'immediate' }
       );
       await request();
 
@@ -521,7 +513,7 @@ describe('getInAppMessages', () => {
           packageName: 'my-lil-website',
           handleLinks: 'open-all-new-tab'
         },
-        true
+        { display: 'immediate' }
       );
       await request();
 
@@ -570,7 +562,7 @@ describe('getInAppMessages', () => {
           packageName: 'my-lil-website',
           handleLinks: 'open-all-same-tab'
         },
-        true
+        { display: 'immediate' }
       );
       await request();
 
@@ -615,7 +607,7 @@ describe('getInAppMessages', () => {
           packageName: 'my-lil-website',
           handleLinks: 'external-new-tab'
         },
-        true
+        { display: 'immediate' }
       );
       await request();
 
@@ -660,7 +652,7 @@ describe('getInAppMessages', () => {
           onOpenNodeToTakeFocus: 'input',
           packageName: 'my-lil-website'
         },
-        true
+        { display: 'immediate' }
       );
       await request();
 
@@ -689,7 +681,7 @@ describe('getInAppMessages', () => {
 
       const { request } = getInAppMessages(
         { count: 10, packageName: 'my-lil-website' },
-        true
+        { display: 'immediate' }
       );
       await request();
 
@@ -706,7 +698,7 @@ describe('getInAppMessages', () => {
     it('should track in app messages delivered', async () => {
       const { request } = getInAppMessages(
         { count: 10, packageName: 'my-lil-website' },
-        true
+        { display: 'immediate' }
       );
       await request();
 
@@ -720,7 +712,7 @@ describe('getInAppMessages', () => {
     it('should not paint another message after 30 seconds if logged out', async () => {
       const { request } = getInAppMessages(
         { count: 10, packageName: 'my-lil-website' },
-        true
+        { display: 'immediate' }
       );
       const { logout } = initialize('fdsafsd');
       await request();
@@ -751,7 +743,7 @@ describe('getInAppMessages', () => {
     it('should call global.postMessage when action:// link is clicked', async () => {
       const { request } = getInAppMessages(
         { count: 10, packageName: 'my-lil-website' },
-        true
+        { display: 'immediate' }
       );
       await request();
 
@@ -799,7 +791,7 @@ describe('getInAppMessages', () => {
 
       const { request } = getInAppMessages(
         { count: 10, packageName: 'my-lil-website' },
-        true
+        { display: 'immediate' }
       );
       await request();
 
@@ -831,7 +823,7 @@ describe('getInAppMessages', () => {
 
       const { request } = getInAppMessages(
         { count: 10, packageName: 'my-lil-website' },
-        true
+        { display: 'immediate' }
       );
       await request();
 
@@ -863,7 +855,7 @@ describe('getInAppMessages', () => {
 
       const { request } = getInAppMessages(
         { count: 10, packageName: 'my-lil-website' },
-        true
+        { display: 'immediate' }
       );
       await request();
 
@@ -895,7 +887,7 @@ describe('getInAppMessages', () => {
 
       const { request } = getInAppMessages(
         { count: 10, packageName: 'my-lil-website' },
-        true
+        { display: 'immediate' }
       );
       await request();
 
@@ -936,7 +928,7 @@ describe('getInAppMessages', () => {
 
       const { request } = getInAppMessages(
         { count: 10, packageName: 'my-lil-website' },
-        true
+        { display: 'immediate' }
       );
       await request();
 
@@ -981,7 +973,7 @@ describe('getInAppMessages', () => {
           packageName: 'my-lil-website',
           handleLinks: 'open-all-same-tab'
         },
-        true
+        { display: 'immediate' }
       );
       await request();
 
@@ -1022,7 +1014,7 @@ describe('getInAppMessages', () => {
 
       const { request } = getInAppMessages(
         { count: 10, packageName: 'my-lil-website' },
-        true
+        { display: 'immediate' }
       );
       await request();
 
@@ -1063,7 +1055,7 @@ describe('getInAppMessages', () => {
 
       const { request } = getInAppMessages(
         { count: 10, packageName: 'my-lil-website' },
-        true
+        { display: 'immediate' }
       );
       await request();
 

--- a/src/inapp/tests/inapp.test.ts
+++ b/src/inapp/tests/inapp.test.ts
@@ -8,6 +8,7 @@ import { getInAppMessages } from '../inapp';
 import { initialize } from '../../authorization';
 import { SDK_VERSION, WEB_PLATFORM } from '../../constants';
 import { createClientError } from '../../utils/testUtils';
+import { DISPLAY_OPTIONS } from '../types';
 
 jest.mock('../../utils/srSpeak', () => ({
   srSpeak: jest.fn()
@@ -131,7 +132,7 @@ describe('getInAppMessages', () => {
     it('should send up correct payload', async () => {
       const response = await getInAppMessages(
         { count: 10, packageName: 'my-lil-website' },
-        { display: 'immediate' }
+        { display: DISPLAY_OPTIONS.immediate }
       ).request();
 
       expect(response.config.params.packageName).toBe('my-lil-website');
@@ -141,7 +142,9 @@ describe('getInAppMessages', () => {
 
     it('should reject if fails client-side validation', async () => {
       try {
-        await getInAppMessages({} as any, { display: 'immediate' }).request();
+        await getInAppMessages({} as any, {
+          display: DISPLAY_OPTIONS.immediate
+        }).request();
       } catch (e) {
         expect(e).toEqual(
           createClientError([
@@ -161,7 +164,7 @@ describe('getInAppMessages', () => {
     it('should return correct values when auto-paint flag is true', async () => {
       const response = await getInAppMessages(
         { count: 10, packageName: 'my-lil-website' },
-        { display: 'immediate' }
+        { display: DISPLAY_OPTIONS.immediate }
       );
       expect(response.pauseMessageStream).toBeDefined();
       expect(response.resumeMessageStream).toBeDefined();
@@ -176,7 +179,7 @@ describe('getInAppMessages', () => {
           count: 10,
           packageName: 'my-lil-website'
         } as any,
-        { display: 'immediate' }
+        { display: DISPLAY_OPTIONS.immediate }
       ).request();
 
       expect(response.config.params.email).toBeUndefined();
@@ -186,7 +189,7 @@ describe('getInAppMessages', () => {
     it('should paint an iframe to the DOM if second argument is { display: "immediate" }', async () => {
       const { request } = getInAppMessages(
         { count: 10, packageName: 'my-lil-website' },
-        { display: 'immediate' }
+        { display: DISPLAY_OPTIONS.immediate }
       );
       await request();
 
@@ -197,7 +200,7 @@ describe('getInAppMessages', () => {
     it('should not paint an iframe to the DOM if second argument is { display: "deferred" }', async () => {
       const { request } = getInAppMessages(
         { count: 10, packageName: 'my-lil-website' },
-        { display: 'deferred' }
+        { display: DISPLAY_OPTIONS.deferred }
       );
       await request();
 
@@ -208,7 +211,7 @@ describe('getInAppMessages', () => {
     it('should paint an iframe to the DOM if second argument is { display: "deferred" } and display fn is called', async () => {
       const { request, triggerDisplayMessages } = getInAppMessages(
         { count: 10, packageName: 'my-lil-website' },
-        { display: 'deferred' }
+        { display: DISPLAY_OPTIONS.deferred }
       );
       await request().then((response) =>
         triggerDisplayMessages(response.data.inAppMessages)
@@ -232,7 +235,7 @@ describe('getInAppMessages', () => {
     it('should remove the iframe when dismiss link is clicked', async () => {
       const { request } = getInAppMessages(
         { count: 10, packageName: 'my-lil-website' },
-        { display: 'immediate' }
+        { display: DISPLAY_OPTIONS.immediate }
       );
       await request();
 
@@ -258,7 +261,7 @@ describe('getInAppMessages', () => {
     it('should remove the iframe when esc key is pressed within the iframe', async () => {
       const { request } = getInAppMessages(
         { count: 10, packageName: 'my-lil-website' },
-        { display: 'immediate' }
+        { display: DISPLAY_OPTIONS.immediate }
       );
       await request();
 
@@ -274,7 +277,7 @@ describe('getInAppMessages', () => {
     it('should remove the iframe when esc key is pressed within the document body', async () => {
       const { request } = getInAppMessages(
         { count: 10, packageName: 'my-lil-website' },
-        { display: 'immediate' }
+        { display: DISPLAY_OPTIONS.immediate }
       );
       await request();
 
@@ -289,7 +292,7 @@ describe('getInAppMessages', () => {
     it('should remove the iframe when overlay is clicked', async () => {
       const { request } = getInAppMessages(
         { count: 10, packageName: 'my-lil-website' },
-        { display: 'immediate' }
+        { display: DISPLAY_OPTIONS.immediate }
       );
       await request();
 
@@ -312,7 +315,7 @@ describe('getInAppMessages', () => {
           packageName: 'my-lil-website',
           closeButton: {}
         },
-        { display: 'immediate' }
+        { display: DISPLAY_OPTIONS.immediate }
       );
       await request();
 
@@ -335,7 +338,7 @@ describe('getInAppMessages', () => {
     it('should paint next message to the DOM after 30s after first is dismissed', async () => {
       const { request } = getInAppMessages(
         { count: 10, packageName: 'my-lil-website' },
-        { display: 'immediate' }
+        { display: DISPLAY_OPTIONS.immediate }
       );
       await request();
 
@@ -365,7 +368,7 @@ describe('getInAppMessages', () => {
     it('should not paint next message to the DOM after 30s if queue is paused', async () => {
       const { request, pauseMessageStream } = getInAppMessages(
         { count: 10, packageName: 'my-lil-website' },
-        { display: 'immediate' }
+        { display: DISPLAY_OPTIONS.immediate }
       );
       await request();
 
@@ -389,7 +392,7 @@ describe('getInAppMessages', () => {
       const { request, pauseMessageStream, resumeMessageStream } =
         getInAppMessages(
           { count: 10, packageName: 'my-lil-website' },
-          { display: 'immediate' }
+          { display: DISPLAY_OPTIONS.immediate }
         );
       await request();
 
@@ -432,7 +435,7 @@ describe('getInAppMessages', () => {
 
       const { request } = getInAppMessages(
         { count: 10, packageName: 'my-lil-website' },
-        { display: 'immediate' }
+        { display: DISPLAY_OPTIONS.immediate }
       );
       await request();
 
@@ -476,7 +479,7 @@ describe('getInAppMessages', () => {
 
       const { request } = getInAppMessages(
         { count: 10, packageName: 'my-lil-website' },
-        { display: 'immediate' }
+        { display: DISPLAY_OPTIONS.immediate }
       );
       await request();
 
@@ -513,7 +516,7 @@ describe('getInAppMessages', () => {
           packageName: 'my-lil-website',
           handleLinks: 'open-all-new-tab'
         },
-        { display: 'immediate' }
+        { display: DISPLAY_OPTIONS.immediate }
       );
       await request();
 
@@ -562,7 +565,7 @@ describe('getInAppMessages', () => {
           packageName: 'my-lil-website',
           handleLinks: 'open-all-same-tab'
         },
-        { display: 'immediate' }
+        { display: DISPLAY_OPTIONS.immediate }
       );
       await request();
 
@@ -607,7 +610,7 @@ describe('getInAppMessages', () => {
           packageName: 'my-lil-website',
           handleLinks: 'external-new-tab'
         },
-        { display: 'immediate' }
+        { display: DISPLAY_OPTIONS.immediate }
       );
       await request();
 
@@ -652,7 +655,7 @@ describe('getInAppMessages', () => {
           onOpenNodeToTakeFocus: 'input',
           packageName: 'my-lil-website'
         },
-        { display: 'immediate' }
+        { display: DISPLAY_OPTIONS.immediate }
       );
       await request();
 
@@ -681,7 +684,7 @@ describe('getInAppMessages', () => {
 
       const { request } = getInAppMessages(
         { count: 10, packageName: 'my-lil-website' },
-        { display: 'immediate' }
+        { display: DISPLAY_OPTIONS.immediate }
       );
       await request();
 
@@ -698,7 +701,7 @@ describe('getInAppMessages', () => {
     it('should track in app messages delivered', async () => {
       const { request } = getInAppMessages(
         { count: 10, packageName: 'my-lil-website' },
-        { display: 'immediate' }
+        { display: DISPLAY_OPTIONS.immediate }
       );
       await request();
 
@@ -712,7 +715,7 @@ describe('getInAppMessages', () => {
     it('should not paint another message after 30 seconds if logged out', async () => {
       const { request } = getInAppMessages(
         { count: 10, packageName: 'my-lil-website' },
-        { display: 'immediate' }
+        { display: DISPLAY_OPTIONS.immediate }
       );
       const { logout } = initialize('fdsafsd');
       await request();
@@ -743,7 +746,7 @@ describe('getInAppMessages', () => {
     it('should call global.postMessage when action:// link is clicked', async () => {
       const { request } = getInAppMessages(
         { count: 10, packageName: 'my-lil-website' },
-        { display: 'immediate' }
+        { display: DISPLAY_OPTIONS.immediate }
       );
       await request();
 
@@ -791,7 +794,7 @@ describe('getInAppMessages', () => {
 
       const { request } = getInAppMessages(
         { count: 10, packageName: 'my-lil-website' },
-        { display: 'immediate' }
+        { display: DISPLAY_OPTIONS.immediate }
       );
       await request();
 
@@ -823,7 +826,7 @@ describe('getInAppMessages', () => {
 
       const { request } = getInAppMessages(
         { count: 10, packageName: 'my-lil-website' },
-        { display: 'immediate' }
+        { display: DISPLAY_OPTIONS.immediate }
       );
       await request();
 
@@ -855,7 +858,7 @@ describe('getInAppMessages', () => {
 
       const { request } = getInAppMessages(
         { count: 10, packageName: 'my-lil-website' },
-        { display: 'immediate' }
+        { display: DISPLAY_OPTIONS.immediate }
       );
       await request();
 
@@ -887,7 +890,7 @@ describe('getInAppMessages', () => {
 
       const { request } = getInAppMessages(
         { count: 10, packageName: 'my-lil-website' },
-        { display: 'immediate' }
+        { display: DISPLAY_OPTIONS.immediate }
       );
       await request();
 
@@ -928,7 +931,7 @@ describe('getInAppMessages', () => {
 
       const { request } = getInAppMessages(
         { count: 10, packageName: 'my-lil-website' },
-        { display: 'immediate' }
+        { display: DISPLAY_OPTIONS.immediate }
       );
       await request();
 
@@ -973,7 +976,7 @@ describe('getInAppMessages', () => {
           packageName: 'my-lil-website',
           handleLinks: 'open-all-same-tab'
         },
-        { display: 'immediate' }
+        { display: DISPLAY_OPTIONS.immediate }
       );
       await request();
 
@@ -1014,7 +1017,7 @@ describe('getInAppMessages', () => {
 
       const { request } = getInAppMessages(
         { count: 10, packageName: 'my-lil-website' },
-        { display: 'immediate' }
+        { display: DISPLAY_OPTIONS.immediate }
       );
       await request();
 
@@ -1055,7 +1058,7 @@ describe('getInAppMessages', () => {
 
       const { request } = getInAppMessages(
         { count: 10, packageName: 'my-lil-website' },
-        { display: 'immediate' }
+        { display: DISPLAY_OPTIONS.immediate }
       );
       await request();
 

--- a/src/inapp/types.ts
+++ b/src/inapp/types.ts
@@ -35,6 +35,11 @@ export interface InAppMessagesRequestParams extends SDKInAppMessagesParams {
   //  userId?: string
 }
 
+export enum DISPLAY {
+  immediate = 'immediate',
+  deferred = 'deferred'
+}
+
 export interface InAppDisplaySetting {
   percentage?: number;
   displayOption?: string;

--- a/src/inapp/types.ts
+++ b/src/inapp/types.ts
@@ -35,7 +35,7 @@ export interface InAppMessagesRequestParams extends SDKInAppMessagesParams {
   //  userId?: string
 }
 
-export enum DISPLAY {
+export enum DISPLAY_OPTIONS {
   immediate = 'immediate',
   deferred = 'deferred'
 }

--- a/src/inapp/types.ts
+++ b/src/inapp/types.ts
@@ -42,6 +42,8 @@ export enum DISPLAY_OPTIONS {
   deferred = 'deferred'
 }
 
+export type DisplayOptions = `${DISPLAY_OPTIONS}`;
+
 export interface InAppDisplaySetting {
   percentage?: number;
   displayOption?: string;

--- a/src/inapp/types.ts
+++ b/src/inapp/types.ts
@@ -42,6 +42,7 @@ export enum DISPLAY_OPTIONS {
   deferred = 'deferred'
 }
 
+/** template literal type: allows string literals to be used for display options */
 export type DisplayOptions = `${DISPLAY_OPTIONS}`;
 
 export interface InAppDisplaySetting {


### PR DESCRIPTION
## JIRA Ticket(s) if any

* [MOB-4490](https://iterable.atlassian.net/browse/MOB-4490)

## Description

getInAppMessages has a second argument which can look like this:

```
getMessages(...options, true);

getMessages(...options, { display: string; })
```

We want to deprecate the usage of the first method. The second method is the newer, scalable option which allows customers to defer the display of the in-app messages to a time later in the future. The boolean value was the original implementation before this option was introduced.

The reason it still exists in the codebase is for backwards compatibility purposes.

## Test Steps

All unit tests pass.