### PR TITLE
[MOB-4933] Delete expired messages from cache & only add new messages if there is space in cache

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -10,6 +10,7 @@ module.exports = {
     '<rootDir>/src/**/__tests__/**/*.{js,jsx,ts,tsx}',
     '<rootDir>/src/**/*.{spec,test}.{js,jsx,ts,tsx}'
   ],
+  setupFiles: ['fake-indexeddb/auto'],
   setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
   moduleNameMapper: pathsToModuleNameMapper(config.compilerOptions.paths, {

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "eslint": "^7.14.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^3.4.0",
+    "fake-indexeddb": "^4.0.0",
     "husky": "^3.1.0",
     "jest": "^27.3.1",
     "lint-staged": "^11.2.6",

--- a/src/inapp/inapp.ts
+++ b/src/inapp/inapp.ts
@@ -177,8 +177,7 @@ export function getInAppMessages(
       });
 
       /** add new messages to the cache if they fit in the cache */
-      const remainingQuota = await determineRemainingStorageQuota();
-      await addNewMessagesToCache(newMessages, remainingQuota);
+      await addNewMessagesToCache(newMessages);
 
       /** return combined response */
       return {

--- a/src/inapp/inapp.ts
+++ b/src/inapp/inapp.ts
@@ -141,7 +141,7 @@ export function getInAppMessages(
       /** combine cached messages with NEW messages in delta response */
       const allMessages: Partial<InAppMessage>[] = [];
       const newMessages: [string, InAppMessage][] = [];
-      inAppMessages.forEach((inAppMessage) => {
+      inAppMessages?.forEach((inAppMessage) => {
         /**
          * if message in response has no content property, then that means it is
          * older than the latest cached message and should be retrieved from the
@@ -205,8 +205,11 @@ export function getInAppMessages(
             ? messageQuota - idbUsage
             : usage && messageQuota - usage;
           return remainingQuota ? remainingQuota : 0;
-        } catch (err) {
-          console.warn('Error determining remaining storage quota', err);
+        } catch (err: any) {
+          console.warn(
+            'Error determining remaining storage quota',
+            err?.response?.data?.clientErrors ?? err
+          );
         }
         return 0;
       };
@@ -242,8 +245,11 @@ export function getInAppMessages(
           });
           try {
             await setMany(messagesToAddToCache);
-          } catch (err) {
-            console.warn('Error adding new messages to the browser cache', err);
+          } catch (err: any) {
+            console.warn(
+              'Error adding new messages to the browser cache',
+              err?.response?.data?.clientErrors ?? err
+            );
           }
         }
       };
@@ -256,8 +262,11 @@ export function getInAppMessages(
           inAppMessages: allMessages
         }
       };
-    } catch (err) {
-      console.warn('Error requesting in-app messages', err);
+    } catch (err: any) {
+      console.warn(
+        'Error requesting in-app messages',
+        err?.response?.data?.clientErrors ?? err
+      );
     }
     return await requestInAppMessages({});
   };

--- a/src/inapp/inapp.ts
+++ b/src/inapp/inapp.ts
@@ -122,9 +122,10 @@ export function getInAppMessages(
       let latestCachedMessageId: string | undefined;
       let latestCreatedAtTimestamp: EpochTimeStamp = 0;
       const expiredMessagesInCache: string[] = [];
+      const now = Date.now();
 
       cachedMessages.forEach(([cachedMessageId, cachedMessage]) => {
-        if (cachedMessage.expiresAt < Date.now()) {
+        if (cachedMessage.expiresAt < now) {
           expiredMessagesInCache.push(cachedMessageId);
         } else if (cachedMessage.createdAt > latestCreatedAtTimestamp) {
           latestCachedMessageId = cachedMessageId;
@@ -161,7 +162,7 @@ export function getInAppMessages(
          */
         if (!inAppMessage.content) {
           const cachedMessage = cachedMessages.find(
-            ([messageId, _]) => inAppMessage.messageId === messageId
+            ([messageId]) => inAppMessage.messageId === messageId
           );
           if (cachedMessage) allMessages.push(cachedMessage[1]);
         } else {

--- a/src/inapp/inapp.ts
+++ b/src/inapp/inapp.ts
@@ -29,7 +29,6 @@ import {
   addButtonAttrsToAnchorTag,
   addNewMessagesToCache,
   addStyleSheet,
-  determineRemainingStorageQuota,
   filterHiddenInAppMessages,
   generateCloseButton,
   getHostnameFromUrl,

--- a/src/inapp/types.ts
+++ b/src/inapp/types.ts
@@ -46,6 +46,11 @@ export interface WebInAppDisplaySettings {
   position: 'Center' | 'TopRight' | 'BottomRight' | 'Full';
 }
 
+export type BrowserStorageEstimate = StorageEstimate & {
+  /** usageDetails not supported in Safari */
+  usageDetails?: { indexedDB?: number };
+};
+
 export interface InAppMessage {
   messageId: string;
   campaignId: number;

--- a/src/inapp/utils.ts
+++ b/src/inapp/utils.ts
@@ -128,16 +128,17 @@ export const determineRemainingStorageQuota = async () => {
 
     /** 50 MB is the typical web browser cache quota for mobile devices */
     const mobileBrowserQuota = 52428800;
+    /** max quota of browser storage that in-apps will potentially fill */
+    const estimatedBrowserQuota = storage?.quota;
     /**
-     * max quota of browser storage that in-apps will potentially fill,
-     * set to 60% of total quota for initial release
+     * determine lower max quota that can be used for message cache,
+     * set to 60% of quota to leave space for other caching needs
+     * on that domain
      */
-    const inAppMaxBrowserQuota = storage?.quota && storage.quota * 0.6;
-    /** determine lower max quota that can be used for message cache */
     const messageQuota =
-      inAppMaxBrowserQuota && inAppMaxBrowserQuota < mobileBrowserQuota
-        ? inAppMaxBrowserQuota
-        : mobileBrowserQuota;
+      ((estimatedBrowserQuota &&
+        Math.min(estimatedBrowserQuota, mobileBrowserQuota)) ??
+        mobileBrowserQuota) * 0.6;
 
     /** how much local storage is being used */
     const usage = storage?.usageDetails?.indexedDB ?? storage?.usage;

--- a/src/inapp/utils.ts
+++ b/src/inapp/utils.ts
@@ -166,33 +166,33 @@ export const addNewMessagesToCache = async (
 ) => {
   const quota = await determineRemainingStorageQuota();
   if (quota > 0) {
-    /** determine total size (in bytes) of new messages to be added to cache */
+    /**
+     * determine total size (in bytes) of new messages to be added to cache
+     * sorted oldest to newest (ascending createdAt property)
+     */
     const messagesWithSizes: {
       messageId: string;
       message: InAppMessage;
       createdAt: number;
       size: number;
-    }[] = messages.map(({ messageId, message }) => {
-      const sizeInBytes = new Blob([
-        JSON.stringify(message).replace(/\[\[\],"\]/g, '')
-      ]).size;
-      return {
-        messageId,
-        message,
-        createdAt: message.createdAt,
-        size: sizeInBytes
-      };
-    });
-
-    /** sort new messages oldest to newest (ascending createdAt property) */
-    const sortedMessages = messagesWithSizes.sort(
-      (a, b) => a.createdAt - b.createdAt
-    );
+    }[] = messages
+      .map(({ messageId, message }) => {
+        const sizeInBytes = new Blob([
+          JSON.stringify(message).replace(/\[\[\],"\]/g, '')
+        ]).size;
+        return {
+          messageId,
+          message,
+          createdAt: message.createdAt,
+          size: sizeInBytes
+        };
+      })
+      .sort((a, b) => a.createdAt - b.createdAt);
 
     /** only add messages that fit in cache, starting from oldest messages */
     let remainingQuota = quota;
     const messagesToAddToCache: [string, InAppMessage][] = [];
-    sortedMessages.forEach(({ messageId, message, size }) => {
+    messagesWithSizes.forEach(({ messageId, message, size }) => {
       if (remainingQuota - size > 0) {
         remainingQuota -= size;
         messagesToAddToCache.push([messageId, message]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2108,6 +2108,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+base64-arraybuffer-es6@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/base64-arraybuffer-es6/-/base64-arraybuffer-es6-0.7.0.tgz#dbe1e6c87b1bf1ca2875904461a7de40f21abc86"
+  integrity sha512-ESyU/U1CFZDJUdr+neHRhNozeCv72Y7Vm0m1DCbjX3KBjT6eYocvAJlSk6+8+HkVwXlT1FNxhGW6q3UKAlCvvw==
+
 base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
@@ -2916,6 +2921,13 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
+domexception@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/domexception/-/domexception-1.0.1.tgz#937442644ca6a31261ef36e3ec677fe805582c90"
+  integrity sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==
+  dependencies:
+    webidl-conversions "^4.0.2"
+
 domexception@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/domexception/-/domexception-2.0.1.tgz#fb44aefba793e1574b0af6aed2801d057529f304"
@@ -3270,6 +3282,13 @@ express@^4.17.1:
     type-is "~1.6.18"
     utils-merge "1.0.1"
     vary "~1.1.2"
+
+fake-indexeddb@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/fake-indexeddb/-/fake-indexeddb-4.0.0.tgz#1dfb2023a3be175e35a6d84975218b432041934d"
+  integrity sha512-oCfWSJ/qvQn1XPZ8SHX6kY3zr1t+bN7faZ/lltGY0SBGhFOPXnWf0+pbO/MOAgfMx6khC2gK3S/bvAgQpuQHDQ==
+  dependencies:
+    realistic-structured-clone "^3.0.0"
 
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
@@ -5621,6 +5640,15 @@ readdirp@~3.6.0:
   dependencies:
     picomatch "^2.2.1"
 
+realistic-structured-clone@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/realistic-structured-clone/-/realistic-structured-clone-3.0.0.tgz#7b518049ce2dad41ac32b421cd297075b00e3e35"
+  integrity sha512-rOjh4nuWkAqf9PWu6JVpOWD4ndI+JHfgiZeMmujYcPi+fvILUu7g6l26TC1K5aBIp34nV+jE1cDO75EKOfHC5Q==
+  dependencies:
+    domexception "^1.0.1"
+    typeson "^6.1.0"
+    typeson-registry "^1.0.0-alpha.20"
+
 rechoir@^0.7.0:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.7.1.tgz#9478a96a1ca135b5e88fc027f03ee92d6c645686"
@@ -6518,6 +6546,20 @@ typescript@^4.6.4:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.4.tgz#caa78bbc3a59e6a5c510d35703f6a09877ce45e9"
   integrity sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==
 
+typeson-registry@^1.0.0-alpha.20:
+  version "1.0.0-alpha.39"
+  resolved "https://registry.yarnpkg.com/typeson-registry/-/typeson-registry-1.0.0-alpha.39.tgz#9e0f5aabd5eebfcffd65a796487541196f4b1211"
+  integrity sha512-NeGDEquhw+yfwNhguLPcZ9Oj0fzbADiX4R0WxvoY8nGhy98IbzQy1sezjoEFWOywOboj/DWehI+/aUlRVrJnnw==
+  dependencies:
+    base64-arraybuffer-es6 "^0.7.0"
+    typeson "^6.0.0"
+    whatwg-url "^8.4.0"
+
+typeson@^6.0.0, typeson@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/typeson/-/typeson-6.1.0.tgz#5b2a53705a5f58ff4d6f82f965917cabd0d7448b"
+  integrity sha512-6FTtyGr8ldU0pfbvW/eOZrEtEkczHRUtduBnA90Jh9kMPCiFNnXIon3vF41N0S4tV1HHQt4Hk1j4srpESziCaA==
+
 unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz#301acdc525631670d39f6146e0e77ff6bbdebddc"
@@ -6660,6 +6702,11 @@ wcwidth@^1.0.1:
   integrity sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=
   dependencies:
     defaults "^1.0.3"
+
+webidl-conversions@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
+  integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
 
 webidl-conversions@^5.0.0:
   version "5.0.0"
@@ -6804,7 +6851,7 @@ whatwg-mimetype@^2.3.0:
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"
   integrity sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==
 
-whatwg-url@^8.0.0, whatwg-url@^8.5.0:
+whatwg-url@^8.0.0, whatwg-url@^8.4.0, whatwg-url@^8.5.0:
   version "8.7.0"
   resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-8.7.0.tgz#656a78e510ff8f3937bc0bcbe9f5c0ac35941b77"
   integrity sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==


### PR DESCRIPTION
## JIRA Ticket(s) if any

* [MOB-4933](https://iterable.atlassian.net/browse/MOB-4933)

## Description

By default (as consistent with our other mobile SDKs), we persist messages in browser cache indefinitely until it reaches the expiration date. Automatically delete expired messages from the cache. Also, calculate remaining cache space and add new messages only if it fits in the cache.

## Test Steps

Send yourself a message that will quickly expire.
Call getMessages.
Check that all messages appear in cache (assuming there's space).
After message expires, call getMessages again.
Observe that expired message gets removed from the cache.