### PR TITLE
[MOB-4940] Prevent caching if indexedDB is not present in browser window + refactoring

### DIFF
--- a/src/inapp/utils.ts
+++ b/src/inapp/utils.ts
@@ -121,12 +121,14 @@ export const sortInAppMessages = (messages: Partial<InAppMessage>[] = []) => {
  */
 export const determineRemainingStorageQuota = async () => {
   try {
+    if (!('indexedDB' in window)) return 0;
+
     const storage: BrowserStorageEstimate | undefined =
       'storage' in navigator && 'estimate' in navigator.storage
         ? await navigator.storage.estimate()
         : undefined;
 
-    /** 50 MB is the typical web browser cache quota for mobile devices */
+    /** 50 MB is the lower common denominator on modern mobile browser caches */
     const mobileBrowserQuota = 52428800;
     /** max quota of browser storage that in-apps will potentially fill */
     const estimatedBrowserQuota = storage?.quota;

--- a/src/inapp/utils.ts
+++ b/src/inapp/utils.ts
@@ -195,11 +195,11 @@ export const addNewMessagesToCache = async (
     /** only add messages that fit in cache, starting from oldest messages */
     let remainingQuota = quota;
     const messagesToAddToCache: [string, InAppMessage][] = [];
-    messagesWithSizes.forEach(({ messageId, message, size }) => {
-      if (remainingQuota - size > 0) {
-        remainingQuota -= size;
-        messagesToAddToCache.push([messageId, message]);
-      }
+    messagesWithSizes.every(({ messageId, message, size }) => {
+      if (remainingQuota - size < 0) return false;
+      remainingQuota -= size;
+      messagesToAddToCache.push([messageId, message]);
+      return true;
     });
 
     try {


### PR DESCRIPTION
## JIRA Ticket(s) if any

* [MOB-4940](https://iterable.atlassian.net/browse/MOB-4940)

## Description

Add early return on determining cache quota size if the window doesn't even have indexedDB.

## Test Steps

All unit tests pass.
Call getMessages and make sure you still get response.