### PR TITLE
[MOB-4959] Do not add autogenerated close button if in-app is displayed in Safari

### DIFF
--- a/src/inapp/inapp.ts
+++ b/src/inapp/inapp.ts
@@ -353,6 +353,15 @@ export function getInAppMessages(
           const isSafari =
             !!ua.match(/safari/i) && !ua.match(/chrome|chromium|crios/i);
 
+          /**
+           * We allow users to dismiss messages by clicking outside of the
+           * message not only when isRequiredToDismissMessage is not true
+           * but also when browser is detected to be Safari, regardless of
+           * whether isRequiredToDismissMessage is true. Safari blocks
+           * all bound event handlers and so we cannot execute Javascript
+           * to listen for click events. As such, we should not prevent users
+           * from being able to dismiss the message by clicking outside of it.
+           */
           if (!payload.closeButton?.isRequiredToDismissMessage || isSafari) {
             overlay.addEventListener('click', () => {
               dismissMessage(activeIframe);
@@ -419,11 +428,15 @@ export function getInAppMessages(
               absoluteDismissButton
             );
 
-            /*
-              here we paint an optional close button if the user provided configuration
-              values. This button is just a quality-of-life feature so that the customer will
-              have an easy way to close the modal outside of the other methods.
-            */
+            /**
+             * Here we paint an optional close button if the user provided configuration
+             * values. This button is just a quality-of-life feature so that the customer will
+             * have an easy way to close the modal outside of the other methods.
+             *
+             * Do not show close button if browser is detected to be Safari because the close
+             * button will not be able to dismiss the message (Safari blocks JS from running
+             * on bound event handlers)
+             */
             if (payload.closeButton && !isSafari) {
               const newButton = generateCloseButton(
                 document,

--- a/src/inapp/inapp.ts
+++ b/src/inapp/inapp.ts
@@ -349,7 +349,11 @@ export function getInAppMessages(
             );
           }
 
-          if (!payload.closeButton?.isRequiredToDismissMessage) {
+          const ua = navigator.userAgent;
+          const isSafari =
+            !!ua.match(/safari/i) && !ua.match(/chrome|chromium|crios/i);
+
+          if (!payload.closeButton?.isRequiredToDismissMessage || isSafari) {
             overlay.addEventListener('click', () => {
               dismissMessage(activeIframe);
               overlay.remove();
@@ -363,11 +367,6 @@ export function getInAppMessages(
               global.removeEventListener('resize', throttledResize);
             });
           }
-
-          const ua = navigator.userAgent;
-          const isSafari =
-            !!ua.match(/safari/i) && !ua.match(/chrome|chromium|crios/i);
-          console.log('isSafari', isSafari);
 
           /*
             create an absolutely positioned button that lies underneath the

--- a/src/inapp/inapp.ts
+++ b/src/inapp/inapp.ts
@@ -364,6 +364,11 @@ export function getInAppMessages(
             });
           }
 
+          const ua = navigator.userAgent;
+          const isSafari =
+            !!ua.match(/safari/i) && !ua.match(/chrome|chromium|crios/i);
+          console.log('isSafari', isSafari);
+
           /*
             create an absolutely positioned button that lies underneath the
             in-app message and takes up full width and height
@@ -420,7 +425,7 @@ export function getInAppMessages(
               values. This button is just a quality-of-life feature so that the customer will
               have an easy way to close the modal outside of the other methods.
             */
-            if (payload.closeButton) {
+            if (payload.closeButton && !isSafari) {
               const newButton = generateCloseButton(
                 document,
                 payload.closeButton?.position,
@@ -456,10 +461,6 @@ export function getInAppMessages(
             ];
             Promise.all(trackRequests).catch((e) => e);
           }
-
-          const ua = navigator.userAgent;
-          const isSafari =
-            !!ua.match(/safari/i) && !ua.match(/chrome|chromium|crios/i);
 
           /* now we'll add click tracking to _all_ anchor tags */
           const links =

--- a/src/inapp/types.ts
+++ b/src/inapp/types.ts
@@ -15,7 +15,7 @@ interface SDKInAppMessagesParams {
     iconPath?: string;
     position?: 'top-left' | 'top-right';
     /* If true, prevent user from dismissing in-app message by clicking outside of message */
-    isRequiredToDismissMessage?: boolean;
+    isRequiredToDismissMessage?: true;
     sideOffset?: string;
     size?: string | number;
     topOffset?: string;

--- a/src/inapp/types.ts
+++ b/src/inapp/types.ts
@@ -15,7 +15,7 @@ interface SDKInAppMessagesParams {
     iconPath?: string;
     position?: 'top-left' | 'top-right';
     /* If true, prevent user from dismissing in-app message by clicking outside of message */
-    isRequiredToDismissMessage?: true;
+    isRequiredToDismissMessage?: boolean;
     sideOffset?: string;
     size?: string | number;
     topOffset?: string;


### PR DESCRIPTION
## JIRA Ticket(s) if any

* [MOB-4959](https://iterable.atlassian.net/browse/MOB-4959)

## Description

Autogenerated close button doesn't work on Safari (desktop and mobile)

## Test Steps
On Safari:
1. Create a web in-app message, including an auto-generated close button 
2. Send to self and visit the website on a mobile device and desktop
3. Web in-app message loads
4. No auto-generated close button appears

On Chrome/Firefox/Edge:
1. Using same message as above, send to self and visit website on a mobile device and desktop
3. Web in-app message loads
4. Clicking the auto-generated close button closes the message