### PR TITLE
[MOB-4989] Render document string instead of iframe in sample app content html

### DIFF
--- a/react-example/src/views/InApp.tsx
+++ b/react-example/src/views/InApp.tsx
@@ -55,7 +55,11 @@ export const InApp: FC<{}> = () => {
     e.preventDefault();
     setIsGettingMessagesRaw(true);
 
-    return getInAppMessages({ count: 20, packageName: 'my-website' })
+    return getInAppMessages(
+      { count: 20, packageName: 'my-website' },
+      { display: 'deferred' }
+    )
+      .request()
       .then((response) => {
         setRawMessageCount(response.data.inAppMessages.length);
         setIsGettingMessagesRaw(false);

--- a/src/inapp/utils.ts
+++ b/src/inapp/utils.ts
@@ -370,7 +370,7 @@ const generateSecuredIFrame = () => {
 export const wrapWithIFrame = (html: string): HTMLIFrameElement => {
   const iframe = generateSecuredIFrame();
   iframe.onload = () => {
-    iframe.contentWindow?.document.write(html);
+    iframe.contentDocument?.write(html);
   };
   return iframe;
 };


### PR DESCRIPTION
## JIRA Ticket(s) if any

* [MOB-4989](https://iterable.atlassian.net/browse/MOB-4989)

## Description

When customer does not use the showInAppMessagesAutomatically param, then the return value for the request promise’s content.html is an iframe (same as if the customer used the triggerDisplayMessages method). For the rendering purposes of the sample app, use the request() method to provide the response with InAppMessage in the content.html response.

## Test Steps

Send html content message to self.
In sample app, click "Get messages (do not auto-display)".
Content.html value should be stringified html (for html content messages).