### PR TITLE
[MOB-4992] Support configuration option for using local cache

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,6 +8,9 @@ export const BASE_URL = process.env.BASE_URL || 'https://api.iterable.com/api';
 
 export const GETMESSAGES_PATH = '/inApp/web/getMessages';
 
+/** @todo update once new endpoint is ready */
+export const CACHE_ENABLED_GETMESSAGES_PATH = '/newEndpoint';
+
 const GET_ENABLE_INAPP_CONSUME = () => {
   try {
     return JSON.parse(process.env.ENABLE_INAPP_CONSUME);

--- a/src/inapp/inapp.ts
+++ b/src/inapp/inapp.ts
@@ -111,7 +111,7 @@ export function getInAppMessages(
     });
 
   const requestMessages = async () => {
-    /** @note method and associated parameter will be enabled once new endpoint is ready */
+    /** @note caching implementation and associated parameter will be enabled once new endpoint is ready */
     // if (!options?.useLocalCache) return await requestInAppMessages({});
     /** @note always early return until then */
     return await requestInAppMessages({});

--- a/src/inapp/inapp.ts
+++ b/src/inapp/inapp.ts
@@ -23,6 +23,7 @@ import schema from './inapp.schema';
 import {
   DisplayOptions,
   DISPLAY_OPTIONS,
+  GetInAppMessagesResponse,
   InAppMessage,
   InAppMessageResponse,
   InAppMessagesRequestParams
@@ -60,18 +61,19 @@ export function getInAppMessages(
 ): IterablePromise<InAppMessageResponse>;
 export function getInAppMessages(
   payload: InAppMessagesRequestParams,
-  showInAppMessagesAutomatically: { display: DisplayOptions }
-): {
-  pauseMessageStream: () => void;
-  resumeMessageStream: () => Promise<HTMLIFrameElement | ''>;
-  request: () => IterablePromise<InAppMessageResponse>;
-  triggerDisplayMessages: (
-    messages: Partial<InAppMessage>[]
-  ) => Promise<HTMLIFrameElement | ''>;
-};
+  options: {
+    display: DisplayOptions;
+    /** @note parameter will be enabled once new endpoint is ready */
+    // useLocalCache?: boolean;
+  }
+): GetInAppMessagesResponse;
 export function getInAppMessages(
   payload: InAppMessagesRequestParams,
-  showInAppMessagesAutomatically?: { display: DisplayOptions }
+  options?: {
+    display: DisplayOptions;
+    /** @note parameter will be enabled once new endpoint is ready */
+    // useLocalCache?: boolean;
+  }
 ) {
   clearMessages();
   const dupedPayload = { ...payload };
@@ -96,6 +98,8 @@ export function getInAppMessages(
   }) =>
     baseIterableRequest<InAppMessageResponse>({
       method: 'GET',
+      /** @note parameter will be enabled once new endpoint is ready */
+      // url: options?.useLocalCache ? CACHE_ENABLED_GETMESSAGES_PATH : GETMESSAGES_PATH,
       url: GETMESSAGES_PATH,
       validation: { params: schema },
       params: {
@@ -107,6 +111,11 @@ export function getInAppMessages(
     });
 
   const requestMessages = async () => {
+    /** @note method and associated parameter will be enabled once new endpoint is ready */
+    // if (!options?.useLocalCache) return await requestInAppMessages({});
+    /** @note always early return until then */
+    return await requestInAppMessages({});
+
     try {
       const cachedMessages: [string, InAppMessage][] = await entries();
 
@@ -186,7 +195,7 @@ export function getInAppMessages(
     return await requestInAppMessages({});
   };
 
-  if (showInAppMessagesAutomatically) {
+  if (options?.display) {
     addStyleSheet(document, ANIMATION_STYLESHEET(payload.animationDuration));
     const paintMessageToDOM = (): Promise<HTMLIFrameElement | ''> => {
       if (parsedMessages?.[messageIndex]) {
@@ -658,8 +667,7 @@ export function getInAppMessages(
       return Promise.resolve('');
     };
 
-    const isDeferred =
-      showInAppMessagesAutomatically.display === DISPLAY_OPTIONS.deferred;
+    const isDeferred = options.display === DISPLAY_OPTIONS.deferred;
 
     const triggerDisplayFn = isDeferred
       ? {

--- a/src/inapp/types.ts
+++ b/src/inapp/types.ts
@@ -1,3 +1,5 @@
+import { IterablePromise } from 'src/types';
+
 interface SDKInAppMessagesParams {
   displayInterval?: number;
   /* what should the screen reader say once the message opens */
@@ -35,6 +37,15 @@ export interface InAppMessagesRequestParams extends SDKInAppMessagesParams {
   */
   //  email?: string;
   //  userId?: string
+}
+
+export interface GetInAppMessagesResponse {
+  pauseMessageStream: () => void;
+  resumeMessageStream: () => Promise<HTMLIFrameElement | ''>;
+  request: () => IterablePromise<InAppMessageResponse>;
+  triggerDisplayMessages: (
+    messages: Partial<InAppMessage>[]
+  ) => Promise<HTMLIFrameElement | ''>;
 }
 
 export enum DISPLAY_OPTIONS {


### PR DESCRIPTION
## JIRA Ticket(s) if any

* [MOB-4992](https://iterable.atlassian.net/browse/MOB-4992)

## Description

We are adding a new API endpoint for message delta (to be used in conjunction with the clientside message caching feature) in the near future. For an improved compatibility experience, we will provide support for an optional `useLocalCache` parameter at a later time, but for GA launch this parameter will not be available to be set. Customers may choose to use this parameter when it becomes available with a minor version update, but customers who do not want/need this feature will be able to do fine without it.

## Test Steps

Send in-app messages to self.
Check that no `latestCachedMessageId` parameter exists on request.
No messages are added to the cache.