### PR TITLE
README updates: Safari + custom links, inAppDelete events, closing message on Safari

### DIFF
--- a/README.md
+++ b/README.md
@@ -874,9 +874,13 @@ https://hello.com
 Upon normal links, Iterable reserves the `iterable://` and `action://` schemas for custom actions that are performed when a link is clicked. The following are links that you can add to your in-app messages for enhanced functionality:
 
 1. `iterable://dismiss` - Removes the in-app message from the screen, queues the next one for presentation, and invokes both [trackInAppClose](#trackInAppClose) and [trackInAppClick](#trackInAppClick)
+
 2. `action://{anything}` - Makes a [`Window.prototype.postMessage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) call with the payload `{ type: 'iterable-action-link', data: '{anything}' }` that can be consumed by the parent website. It also dismisses the message and invokes both [trackInAppClose](#trackInAppClose) and [trackInAppClick](#trackInAppClick)
 
-Upon those, the SDK may reserve more keywords in the future.
+The SDK may reserve more keywords in the future.
+
+:rotating_light: `iterable://` and `action://` links are not supported in the Safari web browser. In Safari, users can close an in-app message by clicking a standard link or clicking away from the message.
+
 
 ## Routing in Single-Page Apps
 

--- a/README.md
+++ b/README.md
@@ -881,7 +881,7 @@ Iterable reserves the `iterable://` and `action://` URL schemas to define custom
 
 The SDK may reserve more keywords in the future.
 
-:rotating_light: `iterable://` and `action://` links are not supported in the Safari web browser. In Safari, users can close an in-app message by clicking a standard link or clicking away from the message.
+:rotating_light: `iterable://` and `action://` links are not supported in the Safari web browser. In Safari, users can close an in-app message by clicking away from the message.
 
 ## Routing in Single-Page Apps
 

--- a/README.md
+++ b/README.md
@@ -871,16 +871,15 @@ https://hello.com
 
 ## Reserved Keyword Links
 
-Upon normal links, Iterable reserves the `iterable://` and `action://` schemas for custom actions that are performed when a link is clicked. The following are links that you can add to your in-app messages for enhanced functionality:
+Iterable reserves the `iterable://` and `action://` URL schemas to define custom link click actions:
 
-1. `iterable://dismiss` - Removes the in-app message from the screen, queues the next one for presentation, and invokes both [trackInAppClose](#trackInAppClose) and [trackInAppClick](#trackInAppClick)
+1. `iterable://dismiss` - Removes the in-app message from the screen, grabs the next one to display, and invokes both [trackInAppClose](#trackInAppClose) and [trackInAppClick](#trackInAppClick).
 
-2. `action://{anything}` - Makes a [`Window.prototype.postMessage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) call with the payload `{ type: 'iterable-action-link', data: '{anything}' }` that can be consumed by the parent website. It also dismisses the message and invokes both [trackInAppClose](#trackInAppClose) and [trackInAppClick](#trackInAppClick)
+2. `action://{anything}` - Makes a [`Window.prototype.postMessage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) call with payload `{ type: 'iterable-action-link', data: '{anything}' }`, to be consumed by the parent website as needed. These links also dismiss the message and invoke [trackInAppClose](#trackInAppClose) and [trackInAppClick](#trackInAppClick).
 
 The SDK may reserve more keywords in the future.
 
 :rotating_light: `iterable://` and `action://` links are not supported in the Safari web browser. In Safari, users can close an in-app message by clicking a standard link or clicking away from the message.
-
 
 ## Routing in Single-Page Apps
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Below are the methods this SDK exposes. See [Iterable's API Docs](https://api.it
 | [`updateUser`](#updateUser)                            | Change data on a user's profile or create a user if none exists                                                                                                        |
 | [`updateUserEmail`](#updateUserEmail)                  | Change a user's email and reauthenticate user with the new email address (in other words, the SDK will call `setEmail` for you)                                        |
 
+The SDK does not track `inAppDelete` events.
+
 :rotating_light: Due to a limitation in Safari browsers, web in-app messages displayed in Safari can't automatically fire `trackInAppClick` events when a link has been clicked. This will impact analytics for Safari users.
 
 # Usage


### PR DESCRIPTION
README updates: 

- Safari doesn't support `iterable://` and `action://` links.
- The SDK does not track `inAppDelete` events