### PR TITLE
docs: correcting spelling and markdown syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ request()
   .catch();
 ```
 
-:rotating*light: \_PLEASE NOTE*: If you choose the `deferred` option, the SDK will _not_ do any filtering or sorting on the messages internally. You will get the messages exactly as they come down from the API, untouched. This means you may (for example) show in-app messages marked `read` or show the messages in the wrong order based on `priority`.
+:rotating_light: *_PLEASE NOTE_*: If you choose the `deferred` option, the SDK will _not_ do any filtering or sorting on the messages internally. You will get the messages exactly as they come down from the API, untouched. This means you may (for example) show in-app messages marked `read` or show the messages in the wrong order based on `priority`.
 
 If you want to keep the default sorting and filtering, please take advantage of the `sortInAppMessages` and `filterHiddenInAppMessages` methods the SDK provides.
 
@@ -555,7 +555,7 @@ import { track } from '@iterable/web-sdk/dist/events';
 
 ## How does the SDK pass up my email / user ID?
 
-This SDK relies on a library called [Axios](https://github.com/axios/axios). For all outgoing XHR requests, the SDK utilities [Axios interceptors](https://github.com/axios/axios#interceptors) to add your user information to the requests.
+This SDK relies on a library called [Axios](https://github.com/axios/axios). For all outgoing XHR requests, the SDK utilizes [Axios interceptors](https://github.com/axios/axios#interceptors) to add your user information to the requests.
 
 ## Ok cool. What if I want to handle this intercepting logic myself instead?
 


### PR DESCRIPTION
## JIRA Ticket(s) if any

N/A

## Description

There was a markdown error when attempting to render the `:rotating_light:` emoji due to missing some characters.

Grammer fix for a paragraph later in the `README.md` documentation.

## Test Steps

N/A