### PR TITLE
[MOB-6229] Reposition close x button

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -40,6 +40,10 @@ export const STATIC_HEADERS = {
 /* how long animations fade/side in for. */
 export const ANIMATION_DURATION = 400;
 
+export const DEFAULT_CLOSE_BUTTON_OFFSET_PERCENTAGE = 4;
+export const CLOSE_X_BUTTON_ID = 'close-x-button';
+export const ABSOLUTE_DISMISS_BUTTON_ID = 'absolute-dismiss-button';
+
 export const ANIMATION_STYLESHEET = (
   animationDuration: number = ANIMATION_DURATION
 ) => `

--- a/src/inapp/inapp.ts
+++ b/src/inapp/inapp.ts
@@ -341,34 +341,25 @@ export function getInAppMessages(
               closeXButton.addEventListener('click', triggerClose);
 
               if (isSafari) {
+                const setPosition = () =>
+                  setCloseButtonPosition(
+                    activeIframe,
+                    closeXButton,
+                    position,
+                    sideOffset,
+                    topOffset
+                  );
+
                 /**
                  * Due to DOM manipulations made in other timeouts when painting the iframe,
                  * getBoundingClientRect() will not work unless it waits for those manipulations
                  * to complete. Setting a trivial timeout here to account for this.
                  */
-                setTimeout(
-                  () =>
-                    setCloseButtonPosition(
-                      activeIframe,
-                      closeXButton,
-                      position,
-                      sideOffset,
-                      topOffset
-                    ),
-                  100
-                );
+                setTimeout(() => setPosition(), 100);
                 document.body.appendChild(closeXButton);
 
                 const repositionCloseButton = () =>
-                  messagePosition !== 'Full'
-                    ? setCloseButtonPosition(
-                        activeIframe,
-                        closeXButton,
-                        position,
-                        sideOffset,
-                        topOffset
-                      )
-                    : null;
+                  messagePosition !== 'Full' ? setPosition() : null;
 
                 global.addEventListener('resize', repositionCloseButton);
               } else {

--- a/src/inapp/inapp.ts
+++ b/src/inapp/inapp.ts
@@ -351,8 +351,8 @@ export function getInAppMessages(
                   () =>
                     setCloseButtonPosition(activeIframe, closeXButton, {
                       position,
-                      topOffset,
-                      sideOffset
+                      sideOffset,
+                      topOffset
                     }),
                   100
                 );
@@ -360,7 +360,11 @@ export function getInAppMessages(
 
                 const repositionCloseButton = () =>
                   messagePosition !== 'Full'
-                    ? setCloseButtonPosition(activeIframe, closeXButton)
+                    ? setCloseButtonPosition(activeIframe, closeXButton, {
+                        position,
+                        sideOffset,
+                        topOffset
+                      })
                     : null;
 
                 global.addEventListener('resize', repositionCloseButton);

--- a/src/inapp/inapp.ts
+++ b/src/inapp/inapp.ts
@@ -1,14 +1,14 @@
-import { delMany, entries } from 'idb-keyval';
+import _ from 'lodash';
 import _set from 'lodash/set';
 import {
+  ABSOLUTE_DISMISS_BUTTON_ID,
   ANIMATION_DURATION,
   ANIMATION_STYLESHEET,
+  CLOSE_X_BUTTON_ID,
+  DEFAULT_CLOSE_BUTTON_OFFSET_PERCENTAGE,
   DISPLAY_INTERVAL_DEFAULT,
   ENABLE_INAPP_CONSUME,
-  GETMESSAGES_PATH,
-  IS_PRODUCTION,
-  SDK_VERSION,
-  WEB_PLATFORM
+  IS_PRODUCTION
 } from 'src/constants';
 import { throttle } from 'throttle-debounce';
 import {
@@ -17,13 +17,11 @@ import {
   trackInAppConsume,
   trackInAppOpen
 } from '../events';
-import { baseIterableRequest } from '../request';
 import { IterablePromise } from '../types';
-import schema from './inapp.schema';
+import { requestMessages } from './request';
 import {
-  CachedMessage,
-  DisplayOptions,
   DISPLAY_OPTIONS,
+  DisplayOptions,
   GetInAppMessagesResponse,
   InAppMessage,
   InAppMessageResponse,
@@ -31,11 +29,9 @@ import {
 } from './types';
 import {
   addButtonAttrsToAnchorTag,
-  addNewMessagesToCache,
   addStyleSheet,
   filterHiddenInAppMessages,
   generateCloseButton,
-  getCachedMessagesToDelete,
   getHostnameFromUrl,
   paintIFrame,
   paintOverlay,
@@ -93,127 +89,22 @@ export function getInAppMessages(
   delete dupedPayload.handleLinks;
   delete dupedPayload.closeButton;
 
-  const requestInAppMessages = ({
-    latestCachedMessageId
-  }: {
-    latestCachedMessageId?: string;
-  }) =>
-    baseIterableRequest<InAppMessageResponse>({
-      method: 'GET',
-      /** @note parameter will be enabled once new endpoint is ready */
-      // url: options?.useLocalCache ? CACHE_ENABLED_GETMESSAGES_PATH : GETMESSAGES_PATH,
-      url: GETMESSAGES_PATH,
-      validation: { params: schema },
-      params: {
-        ...dupedPayload,
-        platform: WEB_PLATFORM,
-        SDKVersion: SDK_VERSION,
-        latestCachedMessageId
-      }
-    });
-
-  const requestMessages = async () => {
-    /** @note caching implementation and associated parameter will be enabled once new endpoint is ready */
-    // if (!options?.useLocalCache) return await requestInAppMessages({});
-    /** @note always early return until then */
-    return await requestInAppMessages({});
-
-    try {
-      const cachedMessages: CachedMessage[] = await entries();
-
-      /** determine most recent cached message */
-      let latestCachedMessageId: string | undefined;
-      let latestCreatedAtTimestamp: EpochTimeStamp = 0;
-      cachedMessages.forEach(([cachedMessageId, cachedMessage]) => {
-        if (cachedMessage.createdAt > latestCreatedAtTimestamp) {
-          latestCachedMessageId = cachedMessageId;
-          latestCreatedAtTimestamp = cachedMessage.createdAt;
-        }
-      });
-
-      /**
-       * call getMessages with latestCachedMessageId to get the message delta
-       * (uncached messages have full detail, rest just have messageId)
-       */
-      const response = await requestInAppMessages({ latestCachedMessageId });
-      const { inAppMessages } = response.data;
-
-      /** combine cached messages with NEW messages in delta response */
-      const allMessages: Partial<InAppMessage>[] = [];
-      const newMessages: { messageId: string; message: InAppMessage }[] = [];
-      inAppMessages?.forEach((inAppMessage) => {
-        /**
-         * if message in response has no content property, then that means it is
-         * older than the latest cached message and should be retrieved from the
-         * cache using the messageId
-         *
-         * expecting messages with no content to look like the last 2 messages...
-         * {
-         *   inAppMessages: [
-         *     { ...messageWithContentHasFullDetails01 },
-         *     { ...messageWithContentHasFullDetails02 },
-         *     { messageId: 'messageWithoutContentHasNoOtherProperties01' },
-         *     { messageId: 'messageWithoutContentHasNoOtherProperties02' }
-         *   ]
-         * }
-         */
-        if (!inAppMessage.content) {
-          const cachedMessage = cachedMessages.find(
-            ([messageId]) => inAppMessage.messageId === messageId
-          );
-          if (cachedMessage) allMessages.push(cachedMessage[1]);
-        } else {
-          allMessages.push(inAppMessage);
-          if (inAppMessage.messageId)
-            newMessages.push({
-              messageId: inAppMessage.messageId,
-              message: inAppMessage as InAppMessage
-            });
-        }
-      });
-
-      /** delete messages not present in fetch from cache */
-      const cachedMessagesToDelete = getCachedMessagesToDelete(
-        cachedMessages,
-        inAppMessages
-      );
-      try {
-        await delMany(cachedMessagesToDelete);
-      } catch (err: any) {
-        console.warn(
-          'Error deleting messages from the browser cache',
-          err?.response?.data?.clientErrors ?? err
-        );
-      }
-
-      /** add new messages to the cache if they fit in the cache */
-      await addNewMessagesToCache(newMessages);
-
-      /** return combined response */
-      return {
-        ...response,
-        data: {
-          inAppMessages: allMessages
-        }
-      };
-    } catch (err: any) {
-      console.warn(
-        'Error requesting in-app messages',
-        err?.response?.data?.clientErrors ?? err
-      );
-    }
-    return await requestInAppMessages({});
-  };
-
   if (options?.display) {
     addStyleSheet(document, ANIMATION_STYLESHEET(payload.animationDuration));
     const paintMessageToDOM = (): Promise<HTMLIFrameElement | ''> => {
       if (parsedMessages?.[messageIndex]) {
         const activeMessage = parsedMessages[messageIndex];
+
         const shouldAnimate =
           activeMessage?.content?.inAppDisplaySettings?.shouldAnimate;
         const position =
           activeMessage?.content?.webInAppDisplaySettings?.position || 'Center';
+
+        const overlay = paintOverlay(
+          activeMessage?.content?.inAppDisplaySettings?.bgColor?.hex,
+          activeMessage?.content?.inAppDisplaySettings?.bgColor?.alpha,
+          shouldAnimate
+        );
 
         const dismissMessage = (
           activeIframe: HTMLIFrameElement,
@@ -260,13 +151,9 @@ export function getInAppMessages(
 
             paintMessageToDOM();
           }, timeToNextMessage);
-        };
 
-        const overlay = paintOverlay(
-          activeMessage?.content?.inAppDisplaySettings?.bgColor?.hex,
-          activeMessage?.content?.inAppDisplaySettings?.bgColor?.alpha,
-          shouldAnimate
-        );
+          overlay.remove();
+        };
 
         /* add the message's html to an iframe and paint it to the DOM */
         return paintIFrame(
@@ -278,28 +165,30 @@ export function getInAppMessages(
           payload.bottomOffset,
           payload.rightOffset
         ).then((activeIframe) => {
+          const activeIframeDocument = activeIframe?.contentDocument;
+
           const throttledResize =
             position !== 'Full'
               ? throttle(750, () => {
                   activeIframe.style.height =
-                    (activeIframe.contentWindow?.document?.body?.scrollHeight ||
-                      0) + 'px';
+                    (activeIframeDocument?.body?.scrollHeight || 0) + 'px';
+
+                  // TODO: update postion of x button upon resize
                 })
               : () => null;
           global.addEventListener('resize', throttledResize);
 
           try {
-            const elementToFocus =
-              activeIframe.contentWindow?.document.body?.querySelector(
-                payload.onOpenNodeToTakeFocus || ''
-              );
+            const elementToFocus = activeIframeDocument?.body?.querySelector(
+              payload.onOpenNodeToTakeFocus || ''
+            );
 
             /* try to focus on the query selector the customer provided  */
             (elementToFocus as HTMLElement).focus();
           } catch (e) {
             /* otherwise, find the first focusable element and focus on that */
             const firstFocusableElement =
-              activeIframe.contentWindow?.document.body?.querySelector(
+              activeIframeDocument?.body?.querySelector(
                 'button, a:not([tabindex="-1"]), input, select, textarea, [tabindex]:not([tabindex="-1"])'
               );
 
@@ -315,17 +204,12 @@ export function getInAppMessages(
           ) => {
             if (event.key === 'Escape') {
               dismissMessage(activeIframe);
-              overlay.remove();
               document.removeEventListener('keydown', documentEventHandler);
-              if (
-                activeIframe?.contentWindow?.document &&
-                !!iframeEventHandler
-              ) {
-                activeIframe.contentWindow?.document.removeEventListener(
+              if (activeIframeDocument && !!iframeEventHandler)
+                activeIframeDocument.removeEventListener(
                   'keydown',
                   iframeEventHandler
                 );
-              }
               global.removeEventListener('resize', throttledResize);
             }
           };
@@ -361,12 +245,11 @@ export function getInAppMessages(
 
           document.addEventListener('keydown', handleDocumentEscPress);
 
-          if (activeIframe?.contentWindow?.document) {
-            activeIframe.contentWindow?.document.addEventListener(
+          if (activeIframeDocument)
+            activeIframeDocument.addEventListener(
               'keydown',
               handleIFrameEscPress
             );
-          }
 
           const ua = navigator.userAgent;
           const isSafari =
@@ -384,10 +267,10 @@ export function getInAppMessages(
           if (!payload.closeButton?.isRequiredToDismissMessage || isSafari) {
             overlay.addEventListener('click', () => {
               dismissMessage(activeIframe);
-              overlay.remove();
+              document.getElementById(CLOSE_X_BUTTON_ID)?.remove();
               document.removeEventListener('keydown', handleDocumentEscPress);
-              if (activeIframe?.contentWindow?.document) {
-                activeIframe.contentWindow?.document.removeEventListener(
+              if (activeIframeDocument) {
+                activeIframeDocument.removeEventListener(
                   'keydown',
                   handleIFrameEscPress
                 );
@@ -405,13 +288,14 @@ export function getInAppMessages(
             their in-app, but within the bounds of the iframe to dismiss it.
 
             The overlay doesn't handle this because the overlay only surrounds the iframe,
-            not the in-app message. So imagine an in-app looking like this:
+            not the in-app message.
           */
-          if (activeIframe?.contentWindow?.document) {
-            const closeXButtonId = 'close-x';
+          if (activeIframeDocument) {
             const absoluteDismissButton = document.createElement('button');
-            const absoluteDismissId = 'absolute-dismiss';
-            absoluteDismissButton.setAttribute('id', absoluteDismissId);
+            absoluteDismissButton.setAttribute(
+              'id',
+              ABSOLUTE_DISMISS_BUTTON_ID
+            );
             absoluteDismissButton.style.cssText = `
                 background: none;
                 color: inherit;
@@ -434,19 +318,18 @@ export function getInAppMessages(
             absoluteDismissButton.tabIndex = -1;
             const triggerClose = () => {
               dismissMessage(activeIframe);
-              overlay.remove();
               document.removeEventListener('keydown', handleDocumentEscPress);
-              if (activeIframe?.contentWindow?.document) {
-                activeIframe.contentWindow?.document.removeEventListener(
+              if (activeIframeDocument)
+                activeIframeDocument.removeEventListener(
                   'keydown',
                   handleIFrameEscPress
                 );
-              }
               global.removeEventListener('resize', throttledResize);
               const closeXButtonElement =
-                document.getElementById(closeXButtonId);
-              const absoluteDismissButtonElement =
-                document.getElementById(absoluteDismissId);
+                document.getElementById(CLOSE_X_BUTTON_ID);
+              const absoluteDismissButtonElement = document.getElementById(
+                ABSOLUTE_DISMISS_BUTTON_ID
+              );
               closeXButtonElement?.remove();
               absoluteDismissButtonElement?.remove();
             };
@@ -462,19 +345,52 @@ export function getInAppMessages(
              * button will not be able to dismiss the message (Safari blocks JS from running
              * on bound event handlers)
              */
-            if (payload.closeButton) {
+            if (payload.closeButton && !_.isEmpty(payload.closeButton)) {
+              const { position, color, size, iconPath, topOffset, sideOffset } =
+                payload.closeButton;
+
               const closeXButton = generateCloseButton(
-                closeXButtonId,
+                CLOSE_X_BUTTON_ID,
                 document,
-                payload.closeButton?.position,
-                payload.closeButton?.color,
-                payload.closeButton?.size,
-                payload.closeButton?.iconPath,
-                payload.closeButton.topOffset,
-                payload.closeButton.sideOffset
+                position,
+                color,
+                size,
+                iconPath,
+                topOffset,
+                sideOffset
               );
               closeXButton.addEventListener('click', triggerClose);
-              document.body.appendChild(closeXButton);
+
+              if (isSafari) {
+                let iframeRect;
+
+                /**
+                 * Due to DOM manipulations made in other timeouts when painting the iframe,
+                 * getBoundingClientRect() will not work unless it waits for those manipulations
+                 * to complete. Setting a trivial timeout here to account for this.
+                 */
+                setTimeout(() => {
+                  iframeRect = activeIframe.getBoundingClientRect();
+
+                  // TODO: handle when offset values are provided
+                  // TODO: handle when position is NOT top right
+
+                  closeXButton.style.top = `${
+                    iframeRect.top +
+                    (DEFAULT_CLOSE_BUTTON_OFFSET_PERCENTAGE / 100) *
+                      iframeRect.height
+                  }px`;
+
+                  closeXButton.style.left = `${
+                    iframeRect.right -
+                    parseInt(closeXButton.style.width, 10) -
+                    (DEFAULT_CLOSE_BUTTON_OFFSET_PERCENTAGE / 100) *
+                      iframeRect.width
+                  }px`;
+                }, 100);
+
+                document.body.appendChild(closeXButton);
+              } else activeIframeDocument?.body.appendChild(closeXButton);
             }
           }
 
@@ -501,8 +417,7 @@ export function getInAppMessages(
           }
 
           /* now we'll add click tracking to _all_ anchor tags */
-          const links =
-            activeIframe.contentDocument?.querySelectorAll('a') || [];
+          const links = activeIframeDocument?.querySelectorAll('a') || [];
 
           links.forEach((link) => {
             const clickedUrl = link.getAttribute('href') || '';
@@ -611,17 +526,15 @@ export function getInAppMessages(
 
                   if (isDismissNode || isActionLink) {
                     dismissMessage(activeIframe, clickedUrl);
-                    overlay.remove();
                     document.removeEventListener(
                       'keydown',
                       handleDocumentEscPress
                     );
-                    if (activeIframe?.contentWindow?.document) {
-                      activeIframe.contentWindow?.document.removeEventListener(
+                    if (activeIframeDocument)
+                      activeIframeDocument.removeEventListener(
                         'keydown',
                         handleIFrameEscPress
                       );
-                    }
                     global.removeEventListener('resize', throttledResize);
                   }
 
@@ -700,7 +613,7 @@ export function getInAppMessages(
 
     return {
       request: (): IterablePromise<InAppMessageResponse> =>
-        requestMessages()
+        requestMessages({ payload: dupedPayload })
           .then((response) => {
             trackMessagesDelivered(
               response.data.inAppMessages || [],
@@ -766,7 +679,7 @@ export function getInAppMessages(
     user doesn't want us to paint messages automatically.
     just return the promise like normal
   */
-  return requestMessages().then((response) => {
+  return requestMessages({ payload: dupedPayload }).then((response) => {
     const messages = response.data.inAppMessages;
     trackMessagesDelivered(messages || [], dupedPayload.packageName);
     const withIframes = messages?.map((message) => {

--- a/src/inapp/inapp.ts
+++ b/src/inapp/inapp.ts
@@ -1,4 +1,3 @@
-import { isEmpty } from 'lodash';
 import _set from 'lodash/set';
 import {
   ABSOLUTE_DISMISS_BUTTON_ID,
@@ -325,7 +324,7 @@ export function getInAppMessages(
              * button will not be able to dismiss the message (Safari blocks JS from running
              * on bound event handlers)
              */
-            if (payload.closeButton && !isEmpty(payload.closeButton)) {
+            if (payload.closeButton) {
               const { position, color, size, iconPath, topOffset, sideOffset } =
                 payload.closeButton;
 

--- a/src/inapp/inapp.ts
+++ b/src/inapp/inapp.ts
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import { isEmpty } from 'lodash';
 import _set from 'lodash/set';
 import {
   ABSOLUTE_DISMISS_BUTTON_ID,
@@ -270,12 +270,11 @@ export function getInAppMessages(
               dismissMessage(activeIframe);
               document.getElementById(CLOSE_X_BUTTON_ID)?.remove();
               document.removeEventListener('keydown', handleDocumentEscPress);
-              if (activeIframeDocument) {
+              if (activeIframeDocument)
                 activeIframeDocument.removeEventListener(
                   'keydown',
                   handleIFrameEscPress
                 );
-              }
               global.removeEventListener('resize', throttledResize);
             });
           }
@@ -327,7 +326,7 @@ export function getInAppMessages(
              * button will not be able to dismiss the message (Safari blocks JS from running
              * on bound event handlers)
              */
-            if (payload.closeButton && !_.isEmpty(payload.closeButton)) {
+            if (payload.closeButton && !isEmpty(payload.closeButton)) {
               const { position, color, size, iconPath, topOffset, sideOffset } =
                 payload.closeButton;
 

--- a/src/inapp/inapp.ts
+++ b/src/inapp/inapp.ts
@@ -349,22 +349,26 @@ export function getInAppMessages(
                  */
                 setTimeout(
                   () =>
-                    setCloseButtonPosition(activeIframe, closeXButton, {
+                    setCloseButtonPosition(
+                      activeIframe,
+                      closeXButton,
                       position,
                       sideOffset,
                       topOffset
-                    }),
+                    ),
                   100
                 );
                 document.body.appendChild(closeXButton);
 
                 const repositionCloseButton = () =>
                   messagePosition !== 'Full'
-                    ? setCloseButtonPosition(activeIframe, closeXButton, {
+                    ? setCloseButtonPosition(
+                        activeIframe,
+                        closeXButton,
                         position,
                         sideOffset,
                         topOffset
-                      })
+                      )
                     : null;
 
                 global.addEventListener('resize', repositionCloseButton);

--- a/src/inapp/inapp.ts
+++ b/src/inapp/inapp.ts
@@ -31,6 +31,7 @@ import {
   addButtonAttrsToAnchorTag,
   addStyleSheet,
   filterHiddenInAppMessages,
+  generateAbsoluteDismissButton,
   generateCloseButton,
   getHostnameFromUrl,
   paintIFrame,
@@ -140,6 +141,8 @@ export function getInAppMessages(
             activeIframe.remove();
           }
 
+          overlay.remove();
+
           const timeToNextMessage = shouldAnimate
             ? (payload.displayInterval || DISPLAY_INTERVAL_DEFAULT) +
               ANIMATION_DURATION
@@ -151,8 +154,6 @@ export function getInAppMessages(
 
             paintMessageToDOM();
           }, timeToNextMessage);
-
-          overlay.remove();
         };
 
         /* add the message's html to an iframe and paint it to the DOM */
@@ -291,31 +292,11 @@ export function getInAppMessages(
             not the in-app message.
           */
           if (activeIframeDocument) {
-            const absoluteDismissButton = document.createElement('button');
-            absoluteDismissButton.setAttribute(
-              'id',
-              ABSOLUTE_DISMISS_BUTTON_ID
-            );
-            absoluteDismissButton.style.cssText = `
-                background: none;
-                color: inherit;
-                border: none;
-                padding: 0;
-                font: inherit;
-                cursor: unset;
-                outline: inherit;
-                height: 100vh;
-                width: 100vw;
-                position: fixed;
-                top: 0;
-                left: 0;
-                z-index: -1;
-              `;
-            /* 
-              don't let the user tab to this button. 
-              It's not necessarily for blind folks to tab over 
-            */
-            absoluteDismissButton.tabIndex = -1;
+            const absoluteDismissButton = generateAbsoluteDismissButton({
+              id: ABSOLUTE_DISMISS_BUTTON_ID,
+              document: isSafari ? document : activeIframeDocument
+            });
+
             const triggerClose = () => {
               dismissMessage(activeIframe);
               document.removeEventListener('keydown', handleDocumentEscPress);
@@ -325,6 +306,7 @@ export function getInAppMessages(
                   handleIFrameEscPress
                 );
               global.removeEventListener('resize', throttledResize);
+
               const closeXButtonElement =
                 document.getElementById(CLOSE_X_BUTTON_ID);
               const absoluteDismissButtonElement = document.getElementById(
@@ -351,7 +333,7 @@ export function getInAppMessages(
 
               const closeXButton = generateCloseButton(
                 CLOSE_X_BUTTON_ID,
-                document,
+                isSafari ? document : activeIframeDocument,
                 position,
                 color,
                 size,

--- a/src/inapp/inapp.ts
+++ b/src/inapp/inapp.ts
@@ -355,12 +355,13 @@ export function getInAppMessages(
                  * getBoundingClientRect() will not work unless it waits for those manipulations
                  * to complete. Setting a trivial timeout here to account for this.
                  */
-                setTimeout(() => setPosition(), 100);
-                document.body.appendChild(closeXButton);
+                setTimeout(() => {
+                  setPosition();
+                  document.body.appendChild(closeXButton);
+                }, 100);
 
                 const repositionCloseButton = () =>
                   messagePosition !== 'Full' ? setPosition() : null;
-
                 global.addEventListener('resize', repositionCloseButton);
               } else {
                 activeIframeDocument?.body.appendChild(closeXButton);

--- a/src/inapp/index.ts
+++ b/src/inapp/index.ts
@@ -1,3 +1,3 @@
 export * from './inapp';
 export * from './types';
-export { filterHiddenInAppMessages, sortInAppMessages } from './utils';
+export * from './utils';

--- a/src/inapp/request.ts
+++ b/src/inapp/request.ts
@@ -1,0 +1,134 @@
+import { GETMESSAGES_PATH, SDK_VERSION, WEB_PLATFORM } from 'src/constants';
+import {
+  CachedMessage,
+  InAppMessage,
+  InAppMessageResponse,
+  InAppMessagesRequestParams,
+  baseIterableRequest
+} from '..';
+import schema from './inapp.schema';
+import { delMany, entries } from 'idb-keyval';
+import { addNewMessagesToCache, getCachedMessagesToDelete } from './utils';
+
+type RequestInAppMessagesProps = {
+  latestCachedMessageId?: string;
+  payload: InAppMessagesRequestParams;
+};
+
+export const requestInAppMessages = ({
+  latestCachedMessageId,
+  payload
+}: RequestInAppMessagesProps) =>
+  baseIterableRequest<InAppMessageResponse>({
+    method: 'GET',
+    /** @note parameter will be enabled once new endpoint is ready */
+    // url: options?.useLocalCache ? CACHE_ENABLED_GETMESSAGES_PATH : GETMESSAGES_PATH,
+    url: GETMESSAGES_PATH,
+    validation: { params: schema },
+    params: {
+      ...payload,
+      platform: WEB_PLATFORM,
+      SDKVersion: SDK_VERSION,
+      latestCachedMessageId
+    }
+  });
+
+type RequestMessagesProps = {
+  payload: InAppMessagesRequestParams;
+};
+
+export const requestMessages = async ({ payload }: RequestMessagesProps) => {
+  /** @note caching implementation and associated parameter will be enabled once new endpoint is ready */
+  // if (!options?.useLocalCache) return await requestInAppMessages({});
+  /** @note always early return until then */
+  return await requestInAppMessages({ payload });
+
+  try {
+    const cachedMessages: CachedMessage[] = await entries();
+
+    /** determine most recent cached message */
+    let latestCachedMessageId: string | undefined;
+    let latestCreatedAtTimestamp: EpochTimeStamp = 0;
+    cachedMessages.forEach(([cachedMessageId, cachedMessage]) => {
+      if (cachedMessage.createdAt > latestCreatedAtTimestamp) {
+        latestCachedMessageId = cachedMessageId;
+        latestCreatedAtTimestamp = cachedMessage.createdAt;
+      }
+    });
+
+    /**
+     * call getMessages with latestCachedMessageId to get the message delta
+     * (uncached messages have full detail, rest just have messageId)
+     */
+    const response = await requestInAppMessages({
+      latestCachedMessageId,
+      payload
+    });
+    const { inAppMessages } = response.data;
+
+    /** combine cached messages with NEW messages in delta response */
+    const allMessages: Partial<InAppMessage>[] = [];
+    const newMessages: { messageId: string; message: InAppMessage }[] = [];
+    inAppMessages?.forEach((inAppMessage) => {
+      /**
+       * if message in response has no content property, then that means it is
+       * older than the latest cached message and should be retrieved from the
+       * cache using the messageId
+       *
+       * expecting messages with no content to look like the last 2 messages...
+       * {
+       *   inAppMessages: [
+       *     { ...messageWithContentHasFullDetails01 },
+       *     { ...messageWithContentHasFullDetails02 },
+       *     { messageId: 'messageWithoutContentHasNoOtherProperties01' },
+       *     { messageId: 'messageWithoutContentHasNoOtherProperties02' }
+       *   ]
+       * }
+       */
+      if (!inAppMessage.content) {
+        const cachedMessage = cachedMessages.find(
+          ([messageId]) => inAppMessage.messageId === messageId
+        );
+        if (cachedMessage) allMessages.push(cachedMessage[1]);
+      } else {
+        allMessages.push(inAppMessage);
+        if (inAppMessage.messageId)
+          newMessages.push({
+            messageId: inAppMessage.messageId,
+            message: inAppMessage as InAppMessage
+          });
+      }
+    });
+
+    /** delete messages not present in fetch from cache */
+    const cachedMessagesToDelete = getCachedMessagesToDelete(
+      cachedMessages,
+      inAppMessages
+    );
+    try {
+      await delMany(cachedMessagesToDelete);
+    } catch (err: any) {
+      console.warn(
+        'Error deleting messages from the browser cache',
+        err?.response?.data?.clientErrors ?? err
+      );
+    }
+
+    /** add new messages to the cache if they fit in the cache */
+    await addNewMessagesToCache(newMessages);
+
+    /** return combined response */
+    return {
+      ...response,
+      data: {
+        inAppMessages: allMessages
+      }
+    };
+  } catch (err: any) {
+    console.warn(
+      'Error requesting in-app messages',
+      err?.response?.data?.clientErrors ?? err
+    );
+  }
+  return await requestInAppMessages({ payload });
+};

--- a/src/inapp/request.ts
+++ b/src/inapp/request.ts
@@ -21,7 +21,7 @@ export const requestInAppMessages = ({
 }: RequestInAppMessagesProps) =>
   baseIterableRequest<InAppMessageResponse>({
     method: 'GET',
-    /** @note parameter will be enabled once new endpoint is ready */
+    /** @note Parameter will be enabled once new endpoint is ready */
     // url: options?.useLocalCache ? CACHE_ENABLED_GETMESSAGES_PATH : GETMESSAGES_PATH,
     url: GETMESSAGES_PATH,
     validation: { params: schema },
@@ -38,15 +38,15 @@ type RequestMessagesProps = {
 };
 
 export const requestMessages = async ({ payload }: RequestMessagesProps) => {
-  /** @note caching implementation and associated parameter will be enabled once new endpoint is ready */
+  /** @note Caching implementation and associated parameter will be enabled once new endpoint is ready */
   // if (!options?.useLocalCache) return await requestInAppMessages({});
-  /** @note always early return until then */
+  /** @note Always early return until then */
   return await requestInAppMessages({ payload });
 
   try {
     const cachedMessages: CachedMessage[] = await entries();
 
-    /** determine most recent cached message */
+    /** Determine most recent cached message */
     let latestCachedMessageId: string | undefined;
     let latestCreatedAtTimestamp: EpochTimeStamp = 0;
     cachedMessages.forEach(([cachedMessageId, cachedMessage]) => {
@@ -57,7 +57,7 @@ export const requestMessages = async ({ payload }: RequestMessagesProps) => {
     });
 
     /**
-     * call getMessages with latestCachedMessageId to get the message delta
+     * Call getMessages with latestCachedMessageId to get the message delta
      * (uncached messages have full detail, rest just have messageId)
      */
     const response = await requestInAppMessages({
@@ -66,16 +66,16 @@ export const requestMessages = async ({ payload }: RequestMessagesProps) => {
     });
     const { inAppMessages } = response.data;
 
-    /** combine cached messages with NEW messages in delta response */
+    /** Combine cached messages with NEW messages in delta response */
     const allMessages: Partial<InAppMessage>[] = [];
     const newMessages: { messageId: string; message: InAppMessage }[] = [];
     inAppMessages?.forEach((inAppMessage) => {
       /**
-       * if message in response has no content property, then that means it is
+       * If message in response has no content property, then that means it is
        * older than the latest cached message and should be retrieved from the
        * cache using the messageId
        *
-       * expecting messages with no content to look like the last 2 messages...
+       * Expecting messages with no content to look like the last 2 messages...
        * {
        *   inAppMessages: [
        *     { ...messageWithContentHasFullDetails01 },
@@ -100,7 +100,7 @@ export const requestMessages = async ({ payload }: RequestMessagesProps) => {
       }
     });
 
-    /** delete messages not present in fetch from cache */
+    /** Delete messages not present in fetch from cache */
     const cachedMessagesToDelete = getCachedMessagesToDelete(
       cachedMessages,
       inAppMessages
@@ -114,10 +114,10 @@ export const requestMessages = async ({ payload }: RequestMessagesProps) => {
       );
     }
 
-    /** add new messages to the cache if they fit in the cache */
+    /** Add new messages to the cache if they fit in the cache */
     await addNewMessagesToCache(newMessages);
 
-    /** return combined response */
+    /** Return combined response */
     return {
       ...response,
       data: {

--- a/src/inapp/request.ts
+++ b/src/inapp/request.ts
@@ -1,13 +1,13 @@
+import { delMany, entries } from 'idb-keyval';
 import { GETMESSAGES_PATH, SDK_VERSION, WEB_PLATFORM } from 'src/constants';
+import { baseIterableRequest } from 'src/request';
+import schema from './inapp.schema';
 import {
   CachedMessage,
   InAppMessage,
   InAppMessageResponse,
-  InAppMessagesRequestParams,
-  baseIterableRequest
-} from '..';
-import schema from './inapp.schema';
-import { delMany, entries } from 'idb-keyval';
+  InAppMessagesRequestParams
+} from './types';
 import { addNewMessagesToCache, getCachedMessagesToDelete } from './utils';
 
 type RequestInAppMessagesProps = {

--- a/src/inapp/tests/inapp.test.ts
+++ b/src/inapp/tests/inapp.test.ts
@@ -332,7 +332,8 @@ describe('getInAppMessages', () => {
       const clickEvent = new MouseEvent('click');
       closeButton?.dispatchEvent(clickEvent);
 
-      expect(document.getElementById('iterable-iframe')).toBe(null);
+      // TODO: Fix this test! closeButton is not found by querySelector...
+      // expect(document.getElementById('iterable-iframe')).toBe(null);
     });
 
     it('should paint next message to the DOM after 30s after first is dismissed', async () => {

--- a/src/inapp/tests/inapp.test.ts
+++ b/src/inapp/tests/inapp.test.ts
@@ -325,12 +325,12 @@ describe('getInAppMessages', () => {
 
       expect(frame?.tagName).toBe('IFRAME');
 
-      const element = document.body.querySelector(
+      const closeButton = document.body.querySelector(
         '[data-qa-custom-close-button]'
       );
 
       const clickEvent = new MouseEvent('click');
-      element?.dispatchEvent(clickEvent);
+      closeButton?.dispatchEvent(clickEvent);
 
       expect(document.getElementById('iterable-iframe')).toBe(null);
     });
@@ -386,7 +386,7 @@ describe('getInAppMessages', () => {
       jest.advanceTimersByTime(32000);
 
       expect(document.body.innerHTML).toBe(
-        '<button id="absolute-dismiss" style="background: none; padding: 0px; cursor: unset; outline: inherit; height: 100vh; width: 100vw; position: fixed; top: 0px; left: 0px; z-index: -1;" tabindex="-1"></button>'
+        '<button id="absolute-dismiss-button" style="background: none; padding: 0px; cursor: unset; outline: inherit; height: 100vh; width: 100vw; position: fixed; top: 0px; left: 0px; z-index: -1;" tabindex="-1"></button>'
       );
     });
 

--- a/src/inapp/tests/inapp.test.ts
+++ b/src/inapp/tests/inapp.test.ts
@@ -2,11 +2,11 @@
  * @jest-environment jsdom
  */
 import MockAdapter from 'axios-mock-adapter';
+import { messages } from '../../__data__/inAppMessages';
 import { initialize } from '../../authorization';
 import { GETMESSAGES_PATH, SDK_VERSION, WEB_PLATFORM } from '../../constants';
 import { baseAxiosRequest } from '../../request';
 import { createClientError } from '../../utils/testUtils';
-import { messages } from '../../__data__/inAppMessages';
 import { getInAppMessages } from '../inapp';
 import { DISPLAY_OPTIONS } from '../types';
 
@@ -313,7 +313,9 @@ describe('getInAppMessages', () => {
         {
           count: 10,
           packageName: 'my-lil-website',
-          closeButton: {}
+          closeButton: {
+            position: 'top-right'
+          }
         },
         { display: DISPLAY_OPTIONS.immediate }
       );
@@ -325,15 +327,14 @@ describe('getInAppMessages', () => {
 
       expect(frame?.tagName).toBe('IFRAME');
 
-      const closeButton = document.body.querySelector(
-        '[data-qa-custom-close-button]'
-      );
+      const closeButton = (
+        frame.contentDocument ?? document
+      )?.body.querySelector('[data-qa-custom-close-button]');
 
       const clickEvent = new MouseEvent('click');
       closeButton?.dispatchEvent(clickEvent);
 
-      // TODO: Fix this test! closeButton is not found by querySelector...
-      // expect(document.getElementById('iterable-iframe')).toBe(null);
+      expect(document.getElementById('iterable-iframe')).toBe(null);
     });
 
     it('should paint next message to the DOM after 30s after first is dismissed', async () => {

--- a/src/inapp/tests/inapp.test.ts
+++ b/src/inapp/tests/inapp.test.ts
@@ -313,9 +313,7 @@ describe('getInAppMessages', () => {
         {
           count: 10,
           packageName: 'my-lil-website',
-          closeButton: {
-            position: 'top-right'
-          }
+          closeButton: {}
         },
         { display: DISPLAY_OPTIONS.immediate }
       );

--- a/src/inapp/tests/utils.test.ts
+++ b/src/inapp/tests/utils.test.ts
@@ -5,7 +5,7 @@ import MockAdapter from 'axios-mock-adapter';
 import { baseAxiosRequest } from '../../request';
 import { srSpeak } from '../../utils/srSpeak';
 import { messages } from '../../__data__/inAppMessages';
-import { CachedMessage, InAppMessage } from '../types';
+import { CachedMessage, CloseButtonPosition, InAppMessage } from '../types';
 import {
   addButtonAttrsToAnchorTag,
   filterHiddenInAppMessages,
@@ -899,7 +899,7 @@ describe('Utils', () => {
       const button = generateCloseButton(
         buttonId,
         document,
-        'top-left',
+        CloseButtonPosition.TopLeft,
         'blue',
         20,
         undefined,
@@ -921,7 +921,7 @@ describe('Utils', () => {
       const rightButton = generateCloseButton(
         buttonId,
         document,
-        'top-right',
+        CloseButtonPosition.TopRight,
         'blue',
         20,
         './assets/something.svg',

--- a/src/inapp/tests/utils.test.ts
+++ b/src/inapp/tests/utils.test.ts
@@ -2,10 +2,10 @@
  * @jest-environment jsdom
  */
 import MockAdapter from 'axios-mock-adapter';
+import { messages } from '../../__data__/inAppMessages';
 import { baseAxiosRequest } from '../../request';
 import { srSpeak } from '../../utils/srSpeak';
-import { messages } from '../../__data__/inAppMessages';
-import { CachedMessage, CloseButtonPosition, InAppMessage } from '../types';
+import { CLOSE_BUTTON_POSITION, CachedMessage, InAppMessage } from '../types';
 import {
   addButtonAttrsToAnchorTag,
   filterHiddenInAppMessages,
@@ -899,7 +899,7 @@ describe('Utils', () => {
       const button = generateCloseButton(
         buttonId,
         document,
-        CloseButtonPosition.TopLeft,
+        CLOSE_BUTTON_POSITION.TopLeft,
         'blue',
         20,
         undefined,
@@ -921,7 +921,7 @@ describe('Utils', () => {
       const rightButton = generateCloseButton(
         buttonId,
         document,
-        CloseButtonPosition.TopRight,
+        CLOSE_BUTTON_POSITION.TopRight,
         'blue',
         20,
         './assets/something.svg',

--- a/src/inapp/types.ts
+++ b/src/inapp/types.ts
@@ -1,5 +1,20 @@
 import { IterablePromise } from 'src/types';
 
+export enum CLOSE_BUTTON_POSITION {
+  TopLeft = 'top-left',
+  TopRight = 'top-right'
+}
+
+export type CloseButtonPosition = `${CLOSE_BUTTON_POSITION}`;
+
+export enum HANDLE_LINKS {
+  OpenAllNewTab = 'open-all-new-tab',
+  OpenAllSameTab = 'open-all-same-tab',
+  ExternalNewTab = 'external-new-tab'
+}
+
+export type HandleLinks = `${HANDLE_LINKS}`;
+
 interface SDKInAppMessagesParams {
   displayInterval?: number;
   /* what should the screen reader say once the message opens */
@@ -11,13 +26,13 @@ interface SDKInAppMessagesParams {
   rightOffset?: string;
   /* how long the in-app messages take to animate in/out */
   animationDuration?: number;
-  handleLinks?: 'open-all-new-tab' | 'open-all-same-tab' | 'external-new-tab';
+  handleLinks?: HandleLinks;
   closeButton?: {
     color?: string;
     iconPath?: string;
-    position?: 'top-left' | 'top-right';
     /* If true, prevent user from dismissing in-app message by clicking outside of message */
     isRequiredToDismissMessage?: boolean;
+    position?: CloseButtonPosition;
     sideOffset?: string;
     size?: string | number;
     topOffset?: string;

--- a/src/inapp/utils.ts
+++ b/src/inapp/utils.ts
@@ -289,13 +289,41 @@ export const generateCloseButton = (
     button.innerHTML = '&#x2715';
   }
 
-  /* 
-    no idea why typescript is saying "ariaLabel" doesn't exist on type HTMLButtonElement.
-    Most likely going to need to upgrade typescript to fix this, but in the meantime, we ignore it.
-  */
   button.ariaLabel = 'Close modal button';
   button.setAttribute('data-qa-custom-close-button', 'true');
   button.setAttribute('id', id);
+  return button;
+};
+
+export const generateAbsoluteDismissButton = ({
+  id,
+  document
+}: {
+  id: string;
+  document: Document;
+}) => {
+  const button = document.createElement('button');
+
+  button.setAttribute('id', id);
+  button.style.cssText = `
+    background: none;
+    color: inherit;
+    border: none;
+    padding: 0;
+    font: inherit;
+    cursor: unset;
+    outline: inherit;
+    height: 100vh;
+    width: 100vw;
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: -1;
+  `;
+
+  /* Don't let the user tab to this button. It's not necessary to tab over. */
+  button.tabIndex = -1;
+
   return button;
 };
 

--- a/src/inapp/utils.ts
+++ b/src/inapp/utils.ts
@@ -697,3 +697,24 @@ export const getHostnameFromUrl = (url: string): string | undefined => {
   const linkHost = url.match(/^https?:\/\/([^/?#]+)(?:[/?#]|$)/i);
   return linkHost?.[1];
 };
+
+export const setCloseButtonPosition = (
+  iframe: HTMLIFrameElement,
+  closeButton: HTMLButtonElement
+) => {
+  const iframeRect = iframe.getBoundingClientRect();
+
+  // TODO: handle when offset values are provided
+  // TODO: handle when position is NOT top right
+
+  closeButton.style.top = `${
+    iframeRect.top +
+    (DEFAULT_CLOSE_BUTTON_OFFSET_PERCENTAGE / 100) * iframeRect.height
+  }px`;
+
+  closeButton.style.left = `${
+    iframeRect.right -
+    parseInt(closeButton.style.width, 10) -
+    (DEFAULT_CLOSE_BUTTON_OFFSET_PERCENTAGE / 100) * iframeRect.width
+  }px`;
+};

--- a/src/inapp/utils.ts
+++ b/src/inapp/utils.ts
@@ -712,21 +712,24 @@ export const setCloseButtonPosition = (
   topOffset?: string
 ) => {
   const iframeRect = iframe.getBoundingClientRect();
+
   const defaultOffset = DEFAULT_CLOSE_BUTTON_OFFSET_PERCENTAGE / 100;
+  const defaultTop = defaultOffset * iframeRect.height;
+  const defaultSide = defaultOffset * iframeRect.width;
+
   const buttonWidth = parseInt(closeButton.style.width, 10);
+  const iframeRightEdge = iframeRect.right - buttonWidth;
 
   closeButton.style.top = topOffset
     ? `calc(${iframeRect.top}px + ${topOffset})`
-    : `${iframeRect.top + defaultOffset * iframeRect.height}px`;
+    : `${iframeRect.top + defaultTop}px`;
 
   if (position === CLOSE_BUTTON_POSITION.TopLeft)
     closeButton.style.left = sideOffset
       ? `calc(${iframeRect.left}px + ${sideOffset})`
-      : `${iframeRect.left + defaultOffset * iframeRect.width}px`;
+      : `${iframeRect.left + defaultSide}px`;
   else
     closeButton.style.left = sideOffset
-      ? `calc(${iframeRect.right - buttonWidth}px - ${sideOffset})`
-      : `${
-          iframeRect.right - buttonWidth - defaultOffset * iframeRect.width
-        }px`;
+      ? `calc(${iframeRightEdge}px - ${sideOffset})`
+      : `${iframeRightEdge - defaultSide}px`;
 };

--- a/src/inapp/utils.ts
+++ b/src/inapp/utils.ts
@@ -7,7 +7,13 @@ import {
 import { WebInAppDisplaySettings } from 'src/inapp';
 import { srSpeak } from 'src/utils/srSpeak';
 import { trackInAppDelivery } from '../events';
-import { BrowserStorageEstimate, CachedMessage, InAppMessage } from './types';
+import {
+  BrowserStorageEstimate,
+  CLOSE_BUTTON_POSITION,
+  CachedMessage,
+  CloseButtonPosition,
+  InAppMessage
+} from './types';
 
 interface Breakpoints {
   smMatches: boolean;
@@ -241,7 +247,7 @@ export const addNewMessagesToCache = async (
 export const generateCloseButton = (
   id: string,
   doc: Document,
-  position?: 'top-right' | 'top-left',
+  position?: CloseButtonPosition,
   color?: string,
   size?: string | number,
   iconPath?: string,
@@ -271,7 +277,7 @@ export const generateCloseButton = (
   `;
   const button = doc.createElement('button');
   button.style.cssText =
-    position === 'top-left'
+    position === CLOSE_BUTTON_POSITION.TopLeft
       ? `
     ${sharedStyles}
     left: ${sideOffset || `${DEFAULT_CLOSE_BUTTON_OFFSET_PERCENTAGE}%`};
@@ -700,21 +706,31 @@ export const getHostnameFromUrl = (url: string): string | undefined => {
 
 export const setCloseButtonPosition = (
   iframe: HTMLIFrameElement,
-  closeButton: HTMLButtonElement
+  closeButton: HTMLButtonElement,
+  buttonParams?: {
+    position?: CloseButtonPosition;
+    topOffset?: string;
+    sideOffset?: string;
+  }
 ) => {
   const iframeRect = iframe.getBoundingClientRect();
 
   // TODO: handle when offset values are provided
   // TODO: handle when position is NOT top right
 
+  // position?: 'top-left' | 'top-right';
+  // sideOffset?: string;
+  // topOffset?: string;
+
   closeButton.style.top = `${
     iframeRect.top +
     (DEFAULT_CLOSE_BUTTON_OFFSET_PERCENTAGE / 100) * iframeRect.height
   }px`;
 
-  closeButton.style.left = `${
-    iframeRect.right -
-    parseInt(closeButton.style.width, 10) -
-    (DEFAULT_CLOSE_BUTTON_OFFSET_PERCENTAGE / 100) * iframeRect.width
-  }px`;
+  if (buttonParams?.position === CLOSE_BUTTON_POSITION.TopRight)
+    closeButton.style.left = `${
+      iframeRect.right -
+      parseInt(closeButton.style.width, 10) -
+      (DEFAULT_CLOSE_BUTTON_OFFSET_PERCENTAGE / 100) * iframeRect.width
+    }px`;
 };

--- a/src/inapp/utils.ts
+++ b/src/inapp/utils.ts
@@ -707,27 +707,25 @@ export const getHostnameFromUrl = (url: string): string | undefined => {
 export const setCloseButtonPosition = (
   iframe: HTMLIFrameElement,
   closeButton: HTMLButtonElement,
-  buttonParams: {
-    position?: CloseButtonPosition;
-    sideOffset?: string;
-    topOffset?: string;
-  }
+  position?: CloseButtonPosition,
+  sideOffset?: string,
+  topOffset?: string
 ) => {
   const iframeRect = iframe.getBoundingClientRect();
   const defaultOffset = DEFAULT_CLOSE_BUTTON_OFFSET_PERCENTAGE / 100;
   const buttonWidth = parseInt(closeButton.style.width, 10);
 
-  closeButton.style.top = buttonParams.topOffset
-    ? `calc(${iframeRect.top}px + ${buttonParams.topOffset})`
+  closeButton.style.top = topOffset
+    ? `calc(${iframeRect.top}px + ${topOffset})`
     : `${iframeRect.top + defaultOffset * iframeRect.height}px`;
 
-  if (buttonParams.position === CLOSE_BUTTON_POSITION.TopLeft)
-    closeButton.style.left = buttonParams.sideOffset
-      ? `calc(${iframeRect.left}px + ${buttonParams.sideOffset})`
+  if (position === CLOSE_BUTTON_POSITION.TopLeft)
+    closeButton.style.left = sideOffset
+      ? `calc(${iframeRect.left}px + ${sideOffset})`
       : `${iframeRect.left + defaultOffset * iframeRect.width}px`;
   else
-    closeButton.style.left = buttonParams.sideOffset
-      ? `calc(${iframeRect.right - buttonWidth}px - ${buttonParams.sideOffset})`
+    closeButton.style.left = sideOffset
+      ? `calc(${iframeRect.right - buttonWidth}px - ${sideOffset})`
       : `${
           iframeRect.right - buttonWidth - defaultOffset * iframeRect.width
         }px`;

--- a/src/inapp/utils.ts
+++ b/src/inapp/utils.ts
@@ -707,30 +707,29 @@ export const getHostnameFromUrl = (url: string): string | undefined => {
 export const setCloseButtonPosition = (
   iframe: HTMLIFrameElement,
   closeButton: HTMLButtonElement,
-  buttonParams?: {
+  buttonParams: {
     position?: CloseButtonPosition;
-    topOffset?: string;
     sideOffset?: string;
+    topOffset?: string;
   }
 ) => {
   const iframeRect = iframe.getBoundingClientRect();
+  const defaultOffset = DEFAULT_CLOSE_BUTTON_OFFSET_PERCENTAGE / 100;
 
   // TODO: handle when offset values are provided
-  // TODO: handle when position is NOT top right
-
-  // position?: 'top-left' | 'top-right';
-  // sideOffset?: string;
-  // topOffset?: string;
 
   closeButton.style.top = `${
-    iframeRect.top +
-    (DEFAULT_CLOSE_BUTTON_OFFSET_PERCENTAGE / 100) * iframeRect.height
+    iframeRect.top + defaultOffset * iframeRect.height
   }px`;
 
-  if (buttonParams?.position === CLOSE_BUTTON_POSITION.TopRight)
+  if (buttonParams.position === CLOSE_BUTTON_POSITION.TopLeft)
+    closeButton.style.left = `${
+      iframeRect.left + defaultOffset * iframeRect.width
+    }px`;
+  else
     closeButton.style.left = `${
       iframeRect.right -
       parseInt(closeButton.style.width, 10) -
-      (DEFAULT_CLOSE_BUTTON_OFFSET_PERCENTAGE / 100) * iframeRect.width
+      defaultOffset * iframeRect.width
     }px`;
 };

--- a/src/inapp/utils.ts
+++ b/src/inapp/utils.ts
@@ -1,6 +1,9 @@
 import { by } from '@pabra/sortby';
 import { setMany } from 'idb-keyval';
-import { ANIMATION_DURATION } from 'src/constants';
+import {
+  ANIMATION_DURATION,
+  DEFAULT_CLOSE_BUTTON_OFFSET_PERCENTAGE
+} from 'src/constants';
 import { WebInAppDisplaySettings } from 'src/inapp';
 import { srSpeak } from 'src/utils/srSpeak';
 import { trackInAppDelivery } from '../events';
@@ -259,7 +262,7 @@ export const generateCloseButton = (
     -moz-osx-font-smoothing: inherit;
     -webkit-appearance: none;
     position: absolute;
-    top: ${topOffset || '4%'};
+    top: ${topOffset || `${DEFAULT_CLOSE_BUTTON_OFFSET_PERCENTAGE}%`};
     width: ${parsedSize};
     height: ${parsedSize};
     font-size: ${parsedSize};
@@ -271,11 +274,11 @@ export const generateCloseButton = (
     position === 'top-left'
       ? `
     ${sharedStyles}
-    left: ${sideOffset || '4%'};
+    left: ${sideOffset || `${DEFAULT_CLOSE_BUTTON_OFFSET_PERCENTAGE}%`};
   `
       : `
     ${sharedStyles}
-    right: ${sideOffset || '4%'};
+    right: ${sideOffset || `${DEFAULT_CLOSE_BUTTON_OFFSET_PERCENTAGE}%`};
   `;
 
   if (iconPath) {
@@ -569,6 +572,7 @@ export const paintIFrame = (
     }
     return iframe;
   });
+
 export const addButtonAttrsToAnchorTag = (node: Element, ariaLabel: string) => {
   node.setAttribute('aria-label', ariaLabel);
   node.setAttribute('role', 'button');

--- a/src/inapp/utils.ts
+++ b/src/inapp/utils.ts
@@ -715,21 +715,20 @@ export const setCloseButtonPosition = (
 ) => {
   const iframeRect = iframe.getBoundingClientRect();
   const defaultOffset = DEFAULT_CLOSE_BUTTON_OFFSET_PERCENTAGE / 100;
+  const buttonWidth = parseInt(closeButton.style.width, 10);
 
-  // TODO: handle when offset values are provided
-
-  closeButton.style.top = `${
-    iframeRect.top + defaultOffset * iframeRect.height
-  }px`;
+  closeButton.style.top = buttonParams.topOffset
+    ? `calc(${iframeRect.top}px + ${buttonParams.topOffset})`
+    : `${iframeRect.top + defaultOffset * iframeRect.height}px`;
 
   if (buttonParams.position === CLOSE_BUTTON_POSITION.TopLeft)
-    closeButton.style.left = `${
-      iframeRect.left + defaultOffset * iframeRect.width
-    }px`;
+    closeButton.style.left = buttonParams.sideOffset
+      ? `calc(${iframeRect.left}px + ${buttonParams.sideOffset})`
+      : `${iframeRect.left + defaultOffset * iframeRect.width}px`;
   else
-    closeButton.style.left = `${
-      iframeRect.right -
-      parseInt(closeButton.style.width, 10) -
-      defaultOffset * iframeRect.width
-    }px`;
+    closeButton.style.left = buttonParams.sideOffset
+      ? `calc(${iframeRect.right - buttonWidth}px - ${buttonParams.sideOffset})`
+      : `${
+          iframeRect.right - buttonWidth - defaultOffset * iframeRect.width
+        }px`;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,6 @@
 export * from 'src/authorization';
 export * from './users';
 export * from './inapp';
-export * from './request';
 export * from './events';
 export * from './commerce';
 export * from './types';


### PR DESCRIPTION
## JIRA Ticket(s) if any

* [MOB-6229](https://iterable.atlassian.net/browse/MOB-6229)

## Description

Close button was being positioned relative to document rather than iframe boundaries.
For non-Safari browsers, return close x button to the iframe document.
For Safari browsers, keep close button on the main document and dynamically reposition relative to iframe boundaries.

## Test Steps

In both Safari and non-Safari browsers:
1. Send in-app to self
2. Call getMessages in application
3. Expected: close x button appears over message iframe according to closeButton params
4. Expected: resizing window keeps close x button over message iframe

[MOB-6229]: https://iterable.atlassian.net/browse/MOB-6229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ