### PR TITLE
[MOB-7175]: add new filter method that leaves in JSON only messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ request()
 
 :rotating_light: *_PLEASE NOTE_*: If you choose the `deferred` option, the SDK will _not_ do any filtering or sorting on the messages internally. You will get the messages exactly as they come down from the API, untouched. This means you may (for example) show in-app messages marked `read` or show the messages in the wrong order based on `priority`.
 
-If you want to keep the default sorting and filtering, please take advantage of the `sortInAppMessages` and `filterHiddenInAppMessages` methods the SDK provides.
+If you want to keep the default sorting and filtering, please take advantage of the `sortInAppMessages` and `filterHiddenInAppMessages` methods the SDK provides. Also see `filterOnlyReadAndNeverTriggerMessages`, which is similar to `filterHiddenInAppMessages` but does not filter out JSON-only messages.
 
 ## initialize
 

--- a/src/inapp/tests/utils.test.ts
+++ b/src/inapp/tests/utils.test.ts
@@ -9,6 +9,7 @@ import { CLOSE_BUTTON_POSITION, CachedMessage, InAppMessage } from '../types';
 import {
   addButtonAttrsToAnchorTag,
   filterHiddenInAppMessages,
+  filterOnlyReadAndNeverTriggerMessages,
   generateCloseButton,
   generateWidth,
   getCachedMessagesToDelete,
@@ -33,7 +34,7 @@ const mockMarkup = `
 `;
 
 describe('Utils', () => {
-  describe('Filtering', () => {
+  describe('filterHiddenInAppMessages', () => {
     it('should filter out read messages', () => {
       expect(filterHiddenInAppMessages()).toEqual([]);
       expect(filterHiddenInAppMessages(messages).every((e) => !e?.read)).toBe(
@@ -125,6 +126,100 @@ describe('Utils', () => {
           }
         ]).length
       ).toBe(0);
+    });
+  });
+
+  describe('filterOnlyReadAndNeverTriggerMessages', () => {
+    it('should filter out read messages', () => {
+      expect(filterOnlyReadAndNeverTriggerMessages()).toEqual([]);
+      expect(
+        filterOnlyReadAndNeverTriggerMessages(messages).every((e) => !e?.read)
+      ).toBe(true);
+      expect(
+        filterOnlyReadAndNeverTriggerMessages([
+          {
+            ...messages[0],
+            read: true
+          },
+          {
+            ...messages[1],
+            read: true
+          }
+        ]).length
+      ).toBe(0);
+      expect(
+        filterOnlyReadAndNeverTriggerMessages([
+          {
+            ...messages[0],
+            trigger: { type: 'good' },
+            read: undefined
+          },
+          {
+            ...messages[1],
+            trigger: { type: 'good' },
+            read: undefined
+          }
+        ]).length
+      ).toBe(2);
+    });
+
+    it('should filter out trigger type "never" messages', () => {
+      expect(
+        filterOnlyReadAndNeverTriggerMessages(messages).every(
+          (e) => !e?.trigger?.type
+        )
+      ).not.toBe('never');
+      expect(
+        filterOnlyReadAndNeverTriggerMessages([
+          {
+            ...messages[0],
+            trigger: { type: 'never' }
+          },
+          {
+            ...messages[1],
+            trigger: { type: 'never' }
+          }
+        ]).length
+      ).toBe(0);
+      expect(
+        filterOnlyReadAndNeverTriggerMessages([
+          {
+            ...messages[0],
+            trigger: undefined
+          },
+          {
+            ...messages[1],
+            trigger: undefined
+          }
+        ]).length
+      ).toBe(2);
+    });
+
+    it('should not filter out messages with no HTML body', () => {
+      expect(
+        filterOnlyReadAndNeverTriggerMessages([
+          {
+            ...messages[0],
+            content: { ...messages[0].content, html: '' }
+          },
+          {
+            ...messages[1],
+            content: { ...messages[0].content, html: '<p>' }
+          }
+        ]).length
+      ).toBe(2);
+      expect(
+        filterOnlyReadAndNeverTriggerMessages([
+          {
+            ...messages[0],
+            content: undefined
+          },
+          {
+            ...messages[1],
+            content: undefined
+          }
+        ]).length
+      ).toBe(2);
     });
   });
 

--- a/src/inapp/utils.ts
+++ b/src/inapp/utils.ts
@@ -120,6 +120,14 @@ export const filterHiddenInAppMessages = (
   });
 };
 
+export const filterOnlyReadAndNeverTriggerMessages = (
+  messages: Partial<InAppMessage>[] = []
+) => {
+  return messages.filter(
+    (eachMessage) => !eachMessage.read && eachMessage.trigger?.type !== 'never'
+  );
+};
+
 export const sortInAppMessages = (messages: Partial<InAppMessage>[] = []) => {
   return messages.sort(by(['priorityLevel', 'asc'], ['createdAt', 'asc']));
 };


### PR DESCRIPTION
## JIRA Ticket(s) if any

* [MOB-7175](https://iterable.atlassian.net/browse/MOB-7175)

Resolves https://github.com/Iterable/iterable-web-sdk/issues/237

## Description

There is a requested use case to have the `filterHiddenInAppMessages` method _not_ filter out JSON only messages. Because this method is used to paint messages to the i-frame and other users may depend on the current logic/behavior, we have opted to build a separate method with similar logic, albeit no longer filtering based on the presence of a message's html contents. 

## Test Steps

[MOB-7175]: https://iterable.atlassian.net/browse/MOB-7175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ