### PR TITLE
Export authorization typings

### DIFF
--- a/example/src/index.ts
+++ b/example/src/index.ts
@@ -3,14 +3,15 @@ import axios from 'axios';
 import {
   initialize,
   getInAppMessages,
-  updateUserEmail
+  updateUserEmail,
+  GenerateJWTPayload
 } from '@iterable/web-sdk';
 
 ((): void => {
   /* set token in the SDK */
   const { setEmail, logout } = initialize(
     process.env.API_KEY || '',
-    ({ email }) => {
+    ({ email }: GenerateJWTPayload) => {
       return axios
         .post(
           'http://localhost:5000/generate',

--- a/src/authorization/authorization.ts
+++ b/src/authorization/authorization.ts
@@ -20,12 +20,12 @@ import { config } from '../utils/config';
 
 const MAX_TIMEOUT = ONE_DAY;
 
-interface GenerateJWTPayload {
+export interface GenerateJWTPayload {
   email?: string;
   userID?: string;
 }
 
-interface WithJWT {
+export interface WithJWT {
   clearRefresh: () => void;
   setEmail: (email: string) => Promise<string>;
   setUserID: (userId: string) => Promise<string>;
@@ -33,7 +33,7 @@ interface WithJWT {
   refreshJwtToken: (authTypes: string) => Promise<string>;
 }
 
-interface WithoutJWT {
+export interface WithoutJWT {
   setNewAuthToken: (newToken?: string) => void;
   clearAuthToken: () => void;
   setEmail: (email: string) => void;


### PR DESCRIPTION
## Description

For our own type safety, we needed access to some of you typings. Currently we patch the library by exporting them ourselves, but I think it's a safe QoL change

## Test Steps

I tested it with the example project. 

For your own project:
- Install the package
- Import `GenerateJWTPayload`, `WithJWT`, `WithoutJWT` in the project