### PR TITLE
easier UUID testing in sample app

### DIFF
--- a/react-example/src/components/LoginForm.tsx
+++ b/react-example/src/components/LoginForm.tsx
@@ -1,4 +1,4 @@
-import { FC, FormEvent, useState } from 'react';
+import { ChangeEvent, FC, FormEvent, useState } from 'react';
 import styled from 'styled-components';
 
 import _TextField from 'src/components/TextField';
@@ -26,14 +26,27 @@ const Form = styled.form`
   }
 `;
 
+const StyledDiv = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+`;
+
 interface Props {
   setEmail: (email: string) => Promise<string>;
+  setUserId: (userId: string) => Promise<string>;
   logout: () => void;
   refreshJwt: (authTypes: string) => Promise<string>;
 }
 
-export const LoginForm: FC<Props> = ({ setEmail, logout, refreshJwt }) => {
-  const [email, updateEmail] = useState<string>(process.env.LOGIN_EMAIL || '');
+export const LoginForm: FC<Props> = ({
+  setEmail,
+  setUserId,
+  logout,
+  refreshJwt
+}) => {
+  const [useEmail, setUseEmail] = useState<boolean>(true);
+  const [user, updateUser] = useState<string>(process.env.LOGIN_EMAIL || '');
 
   const [isEditingUser, setEditingUser] = useState<boolean>(false);
 
@@ -42,12 +55,14 @@ export const LoginForm: FC<Props> = ({ setEmail, logout, refreshJwt }) => {
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    setEmail(email)
+    const setUser = useEmail ? setEmail : setUserId;
+
+    setUser(user)
       .then(() => {
         setEditingUser(false);
-        setLoggedInUser({ type: 'user_update', data: email });
+        setLoggedInUser({ type: 'user_update', data: user });
       })
-      .catch(() => updateEmail('Something went wrong!'));
+      .catch(() => updateUser('Something went wrong!'));
   };
 
   const handleLogout = () => {
@@ -56,60 +71,100 @@ export const LoginForm: FC<Props> = ({ setEmail, logout, refreshJwt }) => {
   };
 
   const handleJwtRefresh = () => {
-    refreshJwt(email);
+    refreshJwt(user);
   };
 
   const handleEditUser = () => {
-    updateEmail(loggedInUser);
+    updateUser(loggedInUser);
     setEditingUser(true);
   };
 
   const handleCancelEditUser = () => {
-    updateEmail('');
+    updateUser('');
     setEditingUser(false);
+  };
+
+  const handleRadioChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setUseEmail(e.target.value === 'email');
   };
 
   const first5 = loggedInUser.substring(0, 5);
   const last9 = loggedInUser.substring(loggedInUser.length - 9);
 
+  const editingUserForm = (
+    <Form onSubmit={handleSubmit}>
+      <TextField
+        onChange={(e) => updateUser(e.target.value)}
+        value={user}
+        placeholder="e.g. hello@gmail.com"
+        required
+      />
+      <Button type="submit">Change</Button>
+      <Button onClick={handleCancelEditUser}>Cancel</Button>
+    </Form>
+  );
+
+  const userIdOrEmailForm = (
+    <Form>
+      <div>
+        <input
+          type="radio"
+          id="userId"
+          name="userId"
+          value="userId"
+          checked={!useEmail}
+          onChange={handleRadioChange}
+        />
+        <label>UserId</label>
+      </div>
+      <div>
+        <input
+          type="radio"
+          id="email"
+          name="email"
+          value="email"
+          checked={useEmail}
+          onChange={handleRadioChange}
+        />
+        <label>Email</label>
+      </div>
+    </Form>
+  );
+
+  const loginForm = (
+    <Form onSubmit={handleSubmit} data-qa-login-form>
+      <TextField
+        onChange={(e) => updateUser(e.target.value)}
+        value={user}
+        placeholder="e.g. hello@gmail.com"
+        required
+        data-qa-login-input
+      />
+      <Button type="submit">Login</Button>
+    </Form>
+  );
+
+  const loggedInButtons = (
+    <>
+      <Button onClick={handleEditUser}>
+        Logged in as {`${first5}...${last9}`} (change)
+      </Button>
+      <Button onClick={handleJwtRefresh}>Manually Refresh JWT Token</Button>
+      <Button onClick={handleLogout}>Logout</Button>
+    </>
+  );
+
+  const loggedInOrEditing = isEditingUser ? editingUserForm : loggedInButtons;
+
   return (
     <>
       {loggedInUser ? (
-        isEditingUser ? (
-          <Form onSubmit={handleSubmit}>
-            <TextField
-              onChange={(e) => updateEmail(e.target.value)}
-              value={email}
-              placeholder="e.g. hello@gmail.com"
-              type="email"
-              required
-            />
-            <Button type="submit">Change</Button>
-            <Button onClick={handleCancelEditUser}>Cancel</Button>
-          </Form>
-        ) : (
-          <>
-            <Button onClick={handleEditUser}>
-              Logged in as {`${first5}...${last9}`} (change)
-            </Button>
-            <Button onClick={handleJwtRefresh}>
-              Manually Refresh JWT Token
-            </Button>
-            <Button onClick={handleLogout}>Logout</Button>
-          </>
-        )
+        loggedInOrEditing
       ) : (
-        <Form onSubmit={handleSubmit} data-qa-login-form>
-          <TextField
-            onChange={(e) => updateEmail(e.target.value)}
-            value={email}
-            placeholder="e.g. hello@gmail.com"
-            type="email"
-            required
-            data-qa-login-input
-          />
-          <Button type="submit">Login</Button>
-        </Form>
+        <StyledDiv>
+          {userIdOrEmailForm}
+          {loginForm}
+        </StyledDiv>
       )}
     </>
   );

--- a/react-example/src/index.tsx
+++ b/react-example/src/index.tsx
@@ -41,15 +41,16 @@ const HomeLink = styled(Link)`
 `;
 
 ((): void => {
-  const { setEmail, logout, refreshJwtToken } = initialize(
+  const { setEmail, setUserID, logout, refreshJwtToken } = initialize(
     process.env.API_KEY || '',
-    ({ email }) => {
+    ({ email, userID }) => {
       return axios
         .post(
           process.env.JWT_GENERATOR || 'http://localhost:5000/generate',
           {
             exp_minutes: 2,
             email,
+            user_id: userID,
             jwt_secret: process.env.JWT_SECRET
           },
           {
@@ -76,6 +77,7 @@ const HomeLink = styled(Link)`
             </HomeLink>
             <LoginForm
               setEmail={setEmail}
+              setUserId={setUserID}
               logout={logout}
               refreshJwt={refreshJwtToken}
             />


### PR DESCRIPTION
## JIRA Ticket(s) if any

* [MOB-8426](https://iterable.atlassian.net/browse/MOB-8426)

## Description

Makes it a bit easier to test UserID behavior in the React example app by allowing you to set which user type to use on login (email or userId).

## Test Steps
1. Regression test that email still works with an email based project
2. Update environment variables to point to a UUID based project
3. Login and make api calls with UUID as opposed to email