### PR TITLE
[MOB-8591] Fix handling of placementIds when retrieving messages in IterableEmbeddedManager

### DIFF
--- a/src/embedded/embeddedManager.ts
+++ b/src/embedded/embeddedManager.ts
@@ -34,9 +34,13 @@ export class IterableEmbeddedManager {
     try {
       const params: any = {};
       if (placementIds.length > 0) {
-        params.placementIds = placementIds
-          .map((id) => `&placementIds=${id}`)
-          .join('');
+        params.placementIds = placementIds[0];
+        if (placementIds.length > 1) {
+          params.placementIds += placementIds
+            .slice(1)
+            .map((id) => `&placementIds=${id}`)
+            .join('');
+        }
       }
       const iterableResult: any = await baseIterableRequest<IterableResponse>({
         method: 'GET',


### PR DESCRIPTION
## JIRA Ticket(s) if any

* [MOB-8591](https://iterable.atlassian.net/browse/MOB-8591)

## Description

In `IterableEmbeddedManager`, `retrieveEmbeddedMessages` is incorrectly setting `placementIds` query parameter.

<img width="806" alt="Screenshot 2024-05-17 at 2 33 20 PM" src="https://github.com/Iterable/iterable-web-sdk/assets/6285/8c2f4698-e873-4c3d-9be2-507b5864c98a">

[MOB-8591]: https://iterable.atlassian.net/browse/MOB-8591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ