### PR TITLE
[MOB-8646]: targetUrl not being sent on click

### DIFF
--- a/react-example/src/components/EmbeddedForm.tsx
+++ b/react-example/src/components/EmbeddedForm.tsx
@@ -104,13 +104,13 @@ export const EmbeddedForm: FC<Props> = ({
     };
 
     const buttonIdentifier = 'button-123';
-    const clickedUrl = 'https://example.com';
+    const targetUrl = 'https://example.com';
     const appPackageName = 'my-lil-site';
 
     trackEmbeddedClick({
       messageId: payload.messageId,
       buttonIdentifier,
-      clickedUrl,
+      targetUrl,
       appPackageName
     })
       .then((response: any) => {

--- a/src/embedded/utils.ts
+++ b/src/embedded/utils.ts
@@ -3,7 +3,8 @@ import {
   IterableEmbeddedButton,
   IterableAction,
   IterableActionSource,
-  IterableEmbeddedMessage
+  IterableEmbeddedMessage,
+  IterableEmbeddedDefaultAction
 } from './types';
 import { IterableActionRunner } from '../utils/IterableActionRunner';
 import { ErrorHandler } from '../types';
@@ -13,7 +14,7 @@ import {
   URL_SCHEME_OPEN
 } from 'src/constants';
 
-function getClickedUrl(action?: any): string {
+function getTargetUrl(action?: IterableEmbeddedDefaultAction): string {
   if (!action) return '';
 
   if (action.type === URL_SCHEME_OPEN) {
@@ -28,7 +29,7 @@ export const handleElementClick = (
   appPackageName: string,
   errorCallback?: ErrorHandler
 ) => {
-  const targetUrl = getClickedUrl(message?.elements?.defaultAction);
+  const targetUrl = getTargetUrl(message?.elements?.defaultAction);
   handleEmbeddedClick(targetUrl);
   trackEmbeddedClick({
     messageId: message.metadata.messageId,
@@ -51,7 +52,7 @@ export const handleButtonClick = (
   appPackageName: string,
   errorCallback?: ErrorHandler
 ) => {
-  const targetUrl = getClickedUrl(button?.action);
+  const targetUrl = getTargetUrl(button?.action);
   handleEmbeddedClick(targetUrl);
   trackEmbeddedClick({
     messageId: message.metadata.messageId,

--- a/src/embedded/utils.ts
+++ b/src/embedded/utils.ts
@@ -28,12 +28,12 @@ export const handleElementClick = (
   appPackageName: string,
   errorCallback?: ErrorHandler
 ) => {
-  const clickedUrl = getClickedUrl(message?.elements?.defaultAction);
-  handleEmbeddedClick(clickedUrl);
+  const targetUrl = getClickedUrl(message?.elements?.defaultAction);
+  handleEmbeddedClick(targetUrl);
   trackEmbeddedClick({
     messageId: message.metadata.messageId,
     buttonIdentifier: '',
-    clickedUrl: clickedUrl,
+    targetUrl,
     appPackageName
   }).catch((error) => {
     if (errorCallback) {
@@ -51,12 +51,12 @@ export const handleButtonClick = (
   appPackageName: string,
   errorCallback?: ErrorHandler
 ) => {
-  const clickedUrl = getClickedUrl(button?.action);
-  handleEmbeddedClick(clickedUrl);
+  const targetUrl = getClickedUrl(button?.action);
+  handleEmbeddedClick(targetUrl);
   trackEmbeddedClick({
     messageId: message.metadata.messageId,
     buttonIdentifier: button?.id || '',
-    clickedUrl,
+    targetUrl,
     appPackageName
   }).catch((error) => {
     if (errorCallback) {

--- a/src/events/embedded/types.ts
+++ b/src/events/embedded/types.ts
@@ -12,8 +12,6 @@ export interface IterableEmbeddedImpression {
 }
 
 export interface IterableEmbeddedDismissRequestPayload {
-  email?: string;
-  userId?: string;
   messageId: string;
   buttonIdentifier: string;
   createdAt: number;
@@ -23,7 +21,7 @@ export interface IterableEmbeddedDismissRequestPayload {
 export interface IterableEmbeddedClickRequestPayload {
   messageId: string;
   buttonIdentifier: string;
-  clickedUrl: string;
+  targetUrl: string;
   appPackageName: string;
 }
 

--- a/src/events/events.test.ts
+++ b/src/events/events.test.ts
@@ -272,12 +272,12 @@ describe('Events Requests', () => {
 
     (global as any).localStorage = localStorageMock;
     const buttonIdentifier = 'button-123';
-    const clickedUrl = 'https://example.com';
+    const targetUrl = 'https://example.com';
     const appPackageName = 'my-lil-site';
     const response = await trackEmbeddedClick({
       messageId: payload.messageId,
       buttonIdentifier,
-      clickedUrl,
+      targetUrl,
       appPackageName
     });
 
@@ -383,7 +383,7 @@ describe('Events Requests', () => {
     const trackEmClickResponse = await trackEmbeddedClick({
       messageId: 'abc123',
       buttonIdentifier: 'button-123',
-      clickedUrl: 'https://example.com',
+      targetUrl: 'https://example.com',
       appPackageName: 'my-lil-site'
     });
     const trackSessionResponse = await trackEmbeddedSession({


### PR DESCRIPTION
## JIRA Ticket(s) if any

* [MOB-8646](https://iterable.atlassian.net/browse/MOB-8646)

## Description

`clickedUrl` isn't a part of the API req so changing it's name to more appropriately match the API. 

## Test Steps

[MOB-8646]: https://iterable.atlassian.net/browse/MOB-8646?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ