### PR TITLE
[MOB-9087]: properly format query params for get requests

### DIFF
--- a/src/embedded/embeddedManager.ts
+++ b/src/embedded/embeddedManager.ts
@@ -33,21 +33,11 @@ export class IterableEmbeddedManager {
     placementIds: number[]
   ) {
     try {
-      const params: any = {};
-      if (placementIds.length > 0) {
-        params.placementIds = placementIds[0];
-        if (placementIds.length > 1) {
-          params.placementIds += placementIds
-            .slice(1)
-            .map((id) => `&placementIds=${id}`)
-            .join('');
-        }
-      }
       const iterableResult: any = await baseIterableRequest<IterableResponse>({
         method: 'GET',
         url: ENDPOINTS.get_embedded_messages.route,
         params: {
-          ...params,
+          placementIds,
           platform: WEB_PLATFORM,
           sdkVersion: SDK_VERSION,
           packageName: packageName

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,4 +1,5 @@
 import Axios, { AxiosRequestConfig } from 'axios';
+import qs from 'qs';
 import { BASE_URL, STATIC_HEADERS, EU_ITERABLE_API } from './constants';
 import { IterablePromise, IterableResponse } from './types';
 import { AnySchema, ValidationError } from 'yup';
@@ -46,6 +47,9 @@ export const baseIterableRequest = <T = any>(
       headers: {
         ...payload.headers,
         ...STATIC_HEADERS
+      },
+      paramsSerializer: (params) => {
+        return qs.stringify(params, { arrayFormat: 'repeat' });
       }
     });
   } catch (error) {


### PR DESCRIPTION
## JIRA Ticket(s) if any

* [MOB-9087](https://iterable.atlassian.net/browse/MOB-9087)

## Description

## Test Steps
1. In the EmbeddedMsgs view in the sample app, pass in additional params to `syncMessages` for the `placementIds` arg. 
2. When `getMessages` is called, make sure the params passed in are properly serialized for a URL. 
3. Test this for `api-inapp` as well. 

[MOB-9087]: https://iterable.atlassian.net/browse/MOB-9087?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<img width="590" alt="Screenshot 2024-07-11 at 11 28 53 AM" src="https://github.com/Iterable/iterable-web-sdk/assets/44011584/50e8ff2a-5f72-4c4a-80c4-c5373ef98842">
<img width="544" alt="Screenshot 2024-07-11 at 11 27 56 AM" src="https://github.com/Iterable/iterable-web-sdk/assets/44011584/49b60b06-5bcf-43bd-850d-e28960a6d6f2">
