### PR TITLE
[DOCS-4818] EUDC instructions update

### DIFF
--- a/README.md
+++ b/README.md
@@ -2349,9 +2349,11 @@ If your Iterable project is hosted on Iterable's [European data center (EUDC)](h
 you'll need to configure Iterable's Web SDK to interact with Iterable's EU-based 
 API endpoints.
 
-To do this use [`initializeWithConfig`](#initializeWithConfig) to initialize
-the SDK (rather then [`initialize`](#initialize)), and set set the 
-`isEuIterableService` configuration option to `true`. For example:
+To do this:
+
+- Use [`initializeWithConfig`](#initializeWithConfig) to initialize the SDK 
+  (rather then [`initialize`](#initialize)).
+- Set the `isEuIterableService` configuration option to `true`. For example:
 
   ```ts
   import { initializeWithConfig } from '@iterable/web-sdk';

--- a/README.md
+++ b/README.md
@@ -2349,14 +2349,9 @@ If your Iterable project is hosted on Iterable's [European data center (EUDC)](h
 you'll need to configure Iterable's Web SDK to interact with Iterable's EU-based 
 API endpoints.
 
-To do this, you have two options:
-
-- On the web server that hosts your site, set the `IS_EU_ITERABLE_SERVICE` 
-  environment variable to `true`. 
-
-- Or, when use [`initializeWithConfig`](#initializeWithConfig) to initialize
-  the SDK (rather then [`initialize`](#initialize)), and set set the 
-  `isEuIterableService` configuration option to `true`. For example:
+To do this use [`initializeWithConfig`](#initializeWithConfig) to initialize
+the SDK (rather then [`initialize`](#initialize)), and set set the 
+`isEuIterableService` configuration option to `true`. For example:
 
   ```ts
   import { initializeWithConfig } from '@iterable/web-sdk';


### PR DESCRIPTION
## JIRA Ticket(s) if any

* [DOCS-4818](https://iterable.atlassian.net/browse/DOCS-4818)

## Description

Removing the environment variable option for specifying that the SDK should point at Iterable's EUDC. Use the config option instead.

[DOCS-4818]: https://iterable.atlassian.net/browse/DOCS-4818?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ