### PR TITLE
[MOB-9703] Added support for fetching new JWT prior to calling merge

### DIFF
--- a/src/anonymousUserTracking/tests/userMergeScenarios.test.ts
+++ b/src/anonymousUserTracking/tests/userMergeScenarios.test.ts
@@ -9,7 +9,8 @@ import {
   SHARED_PREFS_ANON_SESSIONS,
   ENDPOINT_MERGE_USER,
   SHARED_PREF_ANON_USER_ID,
-  SHARED_PREF_ANON_USAGE_TRACKED
+  SHARED_PREF_ANON_USAGE_TRACKED,
+  SHARED_PREF_USER_TOKEN
 } from '../../constants';
 import { track } from '../../events';
 import { getInAppMessages } from '../../inapp';
@@ -462,6 +463,12 @@ describe('UserMergeScenariosTests', () => {
         }
       });
       logout(); // logout to remove logged in users before this test
+      (localStorage.getItem as jest.Mock).mockImplementation((key) => {
+        if (key === SHARED_PREF_USER_TOKEN) {
+          return MOCK_JWT_KEY;
+        }
+        return null;
+      });
       await setUserID('testuser123');
       const response = await getInAppMessages({
         count: 10,
@@ -474,6 +481,12 @@ describe('UserMergeScenariosTests', () => {
       expect(localStorageMock.setItem).not.toHaveBeenCalledWith(
         SHARED_PREF_ANON_USER_ID
       );
+      (localStorage.getItem as jest.Mock).mockImplementation((key) => {
+        if (key === SHARED_PREF_USER_TOKEN) {
+          return MOCK_JWT_KEY_WITH_ONE_MINUTE_EXPIRY;
+        }
+        return null;
+      });
       await setUserID('testuseranotheruser');
       const secondResponse = await getInAppMessages({
         count: 10,
@@ -886,6 +899,12 @@ describe('UserMergeScenariosTests', () => {
         }
       });
       logout(); // logout to remove logged in users before this test
+      (localStorage.getItem as jest.Mock).mockImplementation((key) => {
+        if (key === SHARED_PREF_USER_TOKEN) {
+          return MOCK_JWT_KEY;
+        }
+        return null;
+      });
       await setEmail('testuser123@test.com');
       const response = await getInAppMessages({
         count: 10,
@@ -903,6 +922,12 @@ describe('UserMergeScenariosTests', () => {
       expect(localStorageMock.setItem).not.toHaveBeenCalledWith(
         SHARED_PREF_ANON_USER_ID
       );
+      (localStorage.getItem as jest.Mock).mockImplementation((key) => {
+        if (key === SHARED_PREF_USER_TOKEN) {
+          return MOCK_JWT_KEY_WITH_ONE_MINUTE_EXPIRY;
+        }
+        return null;
+      });
       await setEmail('testuseranotheruser@test.com');
       const secondResponse = await getInAppMessages({
         count: 10,

--- a/src/authorization/authorization.test.ts
+++ b/src/authorization/authorization.test.ts
@@ -6,7 +6,11 @@ import { getInAppMessages } from '../inapp';
 import { track, trackInAppClose } from '../events';
 import { updateSubscriptions, updateUser, updateUserEmail } from '../users';
 import { trackPurchase, updateCart } from '../commerce';
-import { GETMESSAGES_PATH, INITIALIZE_ERROR } from '../constants';
+import {
+  GETMESSAGES_PATH,
+  INITIALIZE_ERROR,
+  SHARED_PREF_USER_TOKEN
+} from '../constants';
 
 const localStorageMock = {
   getItem: jest.fn(),
@@ -102,7 +106,12 @@ describe('API Key Interceptors', () => {
       const { setEmail } = initialize('123', () =>
         Promise.resolve(MOCK_JWT_KEY)
       );
-      (global as any).localStorage = localStorageMock;
+      (localStorage.getItem as jest.Mock).mockImplementation((key) => {
+        if (key === SHARED_PREF_USER_TOKEN) {
+          return MOCK_JWT_KEY;
+        }
+        return null;
+      });
       await setEmail('hello@gmail.com');
 
       const response = await getInAppMessages({

--- a/src/authorization/authorization.ts
+++ b/src/authorization/authorization.ts
@@ -106,7 +106,7 @@ const getAnonUserId = () => {
 const initializeUserId = (userId: string) => {
   addUserIdToRequest(userId);
   clearAnonymousUser();
-}
+};
 
 const addUserIdToRequest = (userId: string) => {
   setTypeOfAuth('userID');
@@ -206,7 +206,7 @@ const addUserIdToRequest = (userId: string) => {
 const initializeEmailUser = (email: string) => {
   addEmailToRequest(email);
   clearAnonymousUser();
-}
+};
 
 const syncEvents = () => {
   if (config.getConfig('enableAnonTracking')) {
@@ -463,12 +463,20 @@ export function initialize(
           baseAxiosRequest.interceptors.request.eject(authInterceptor);
         }
       },
-      setEmail: async (email: string, identityResolution?: IdentityResolution) => {
+      setEmail: async (
+        email: string,
+        identityResolution?: IdentityResolution
+      ) => {
         clearMessages();
         try {
-          const identityResolutionConfig = config.getConfig('identityResolution');
-          const merge = identityResolution?.mergeOnAnonymousToKnown || identityResolutionConfig?.mergeOnAnonymousToKnown;
-          const replay = identityResolution?.replayOnVisitorToKnown || identityResolutionConfig?.replayOnVisitorToKnown;
+          const identityResolutionConfig =
+            config.getConfig('identityResolution');
+          const merge =
+            identityResolution?.mergeOnAnonymousToKnown ||
+            identityResolutionConfig?.mergeOnAnonymousToKnown;
+          const replay =
+            identityResolution?.replayOnVisitorToKnown ||
+            identityResolutionConfig?.replayOnVisitorToKnown;
 
           const result = await tryMergeUser(email, true, merge);
           if (result) {
@@ -483,12 +491,20 @@ export function initialize(
           return Promise.reject(`merging failed: ${error}`);
         }
       },
-      setUserID: async (userId: string, identityResolution?: IdentityResolution) => {
+      setUserID: async (
+        userId: string,
+        identityResolution?: IdentityResolution
+      ) => {
         clearMessages();
         try {
-          const identityResolutionConfig = config.getConfig('identityResolution');
-          const merge = identityResolution?.mergeOnAnonymousToKnown || identityResolutionConfig?.mergeOnAnonymousToKnown;
-          const replay = identityResolution?.replayOnVisitorToKnown || identityResolutionConfig?.replayOnVisitorToKnown;
+          const identityResolutionConfig =
+            config.getConfig('identityResolution');
+          const merge =
+            identityResolution?.mergeOnAnonymousToKnown ||
+            identityResolutionConfig?.mergeOnAnonymousToKnown;
+          const replay =
+            identityResolution?.replayOnVisitorToKnown ||
+            identityResolutionConfig?.replayOnVisitorToKnown;
 
           const result = await tryMergeUser(userId, false, merge);
           if (result) {
@@ -807,31 +823,40 @@ export function initialize(
       /* this will just clear the existing timeout */
       handleTokenExpiration('');
     },
-    setEmail: async (email: string, identityResolution?: IdentityResolution) => {
+    setEmail: async (
+      email: string,
+      identityResolution?: IdentityResolution
+    ) => {
       /* clear previous user */
       clearMessages();
       try {
         const identityResolutionConfig = config.getConfig('identityResolution');
-        const merge = identityResolution?.mergeOnAnonymousToKnown || identityResolutionConfig?.mergeOnAnonymousToKnown;
-        const replay = identityResolution?.replayOnVisitorToKnown || identityResolutionConfig?.replayOnVisitorToKnown;
+        const merge =
+          identityResolution?.mergeOnAnonymousToKnown ||
+          identityResolutionConfig?.mergeOnAnonymousToKnown;
+        const replay =
+          identityResolution?.replayOnVisitorToKnown ||
+          identityResolutionConfig?.replayOnVisitorToKnown;
 
         const result = await tryMergeUser(email, true, merge);
         if (result) {
           initializeEmailUser(email);
           try {
-            return doRequest({ email }).then((token) => {
-              if (replay) {
-                syncEvents();
-              }
-              return token;
-            }).catch((e) => {
-              if (logLevel === 'verbose') {
-                console.warn(
-                  'Could not generate JWT after calling setEmail. Please try calling setEmail again.'
-                );
-              }
-              return Promise.reject(e);
-            });
+            return doRequest({ email })
+              .then((token) => {
+                if (replay) {
+                  syncEvents();
+                }
+                return token;
+              })
+              .catch((e) => {
+                if (logLevel === 'verbose') {
+                  console.warn(
+                    'Could not generate JWT after calling setEmail. Please try calling setEmail again.'
+                  );
+                }
+                return Promise.reject(e);
+              });
           } catch (e) {
             /* failed to create a new user. Just silently resolve */
             return Promise.resolve();
@@ -842,12 +867,19 @@ export function initialize(
         return Promise.reject(`merging failed: ${error}`);
       }
     },
-    setUserID: async (userId: string, identityResolution?: IdentityResolution) => {
+    setUserID: async (
+      userId: string,
+      identityResolution?: IdentityResolution
+    ) => {
       clearMessages();
       try {
         const identityResolutionConfig = config.getConfig('identityResolution');
-        const merge = identityResolution?.mergeOnAnonymousToKnown || identityResolutionConfig?.mergeOnAnonymousToKnown;
-        const replay = identityResolution?.replayOnVisitorToKnown || identityResolutionConfig?.replayOnVisitorToKnown;
+        const merge =
+          identityResolution?.mergeOnAnonymousToKnown ||
+          identityResolutionConfig?.mergeOnAnonymousToKnown;
+        const replay =
+          identityResolution?.replayOnVisitorToKnown ||
+          identityResolutionConfig?.replayOnVisitorToKnown;
 
         const result = await tryMergeUser(userId, false, merge);
         if (result) {

--- a/src/authorization/authorization.ts
+++ b/src/authorization/authorization.ts
@@ -9,8 +9,7 @@ import {
   ENDPOINTS,
   RouteConfig,
   SHARED_PREF_ANON_USAGE_TRACKED,
-  SHARED_PREFS_CRITERIA,
-  SHARED_PREF_USER_TOKEN
+  SHARED_PREFS_CRITERIA
 } from 'src/constants';
 import {
   cancelAxiosRequestAndMakeFetch,
@@ -29,6 +28,7 @@ import {
 } from 'src/anonymousUserTracking/anonymousUserEventManager';
 import { IdentityResolution, Options, config } from 'src/utils/config';
 import { getTypeOfAuth, setTypeOfAuth, TypeOfAuth } from 'src/utils/typeOfAuth';
+import AuthorizationToken from 'src/utils/authorizationToken';
 
 const MAX_TIMEOUT = ONE_DAY;
 let authIdentifier: null | string = null;
@@ -66,24 +66,6 @@ export interface WithoutJWT {
   setUserID: (userId: string) => Promise<void>;
   logout: () => void;
   toggleAnonUserTrackingConsent: (consent: boolean) => void;
-}
-
-export class AuthorizationToken {
-  constructor(public token?: string) {}
-
-  setToken(token: string) {
-    this.token = token;
-    localStorage.setItem(SHARED_PREF_USER_TOKEN, token);
-  }
-
-  getToken(): string | null {
-    return this.token || localStorage.getItem(SHARED_PREF_USER_TOKEN);
-  }
-
-  clearToken() {
-    this.token = '';
-    localStorage.removeItem(SHARED_PREF_USER_TOKEN);
-  }
 }
 
 export const setAnonUserId = async (userId: string) => {

--- a/src/authorization/authorization.ts
+++ b/src/authorization/authorization.ts
@@ -838,29 +838,29 @@ export function initialize(
           identityResolution?.replayOnVisitorToKnown ||
           identityResolutionConfig?.replayOnVisitorToKnown;
 
-        const result = await tryMergeUser(email, true, merge);
-        if (result) {
-          initializeEmailUser(email);
-          try {
-            return doRequest({ email })
-              .then((token) => {
+        try {
+          return doRequest({ email })
+            .then(async (token) => {
+              const result = await tryMergeUser(email, true, merge);
+              if (result) {
+                initializeEmailUser(email);
                 if (replay) {
                   syncEvents();
                 }
                 return token;
-              })
-              .catch((e) => {
-                if (logLevel === 'verbose') {
-                  console.warn(
-                    'Could not generate JWT after calling setEmail. Please try calling setEmail again.'
-                  );
-                }
-                return Promise.reject(e);
-              });
-          } catch (e) {
-            /* failed to create a new user. Just silently resolve */
-            return Promise.resolve();
-          }
+              }
+            })
+            .catch((e) => {
+              if (logLevel === 'verbose') {
+                console.warn(
+                  'Could not generate JWT after calling setEmail. Please try calling setEmail again.'
+                );
+              }
+              return Promise.reject(e);
+            });
+        } catch (e) {
+          /* failed to create a new user. Just silently resolve */
+          return Promise.resolve();
         }
       } catch (error) {
         // here we will not sync events but just bubble up error of merge
@@ -881,29 +881,29 @@ export function initialize(
           identityResolution?.replayOnVisitorToKnown ||
           identityResolutionConfig?.replayOnVisitorToKnown;
 
-        const result = await tryMergeUser(userId, false, merge);
-        if (result) {
-          initializeUserId(userId);
-          try {
-            return doRequest({ userID: userId })
-              .then(async (token) => {
+        try {
+          return doRequest({ userID: userId })
+            .then(async (token) => {
+              const result = await tryMergeUser(userId, false, merge);
+              if (result) {
+                initializeUserId(userId);
                 if (replay) {
                   syncEvents();
                 }
                 return token;
-              })
-              .catch((e) => {
-                if (logLevel === 'verbose') {
-                  console.warn(
-                    'Could not generate JWT after calling setUserID. Please try calling setUserID again.'
-                  );
-                }
-                return Promise.reject(e);
-              });
-          } catch (e) {
-            /* failed to create a new user. Just silently resolve */
-            return Promise.resolve();
-          }
+              }
+            })
+            .catch((e) => {
+              if (logLevel === 'verbose') {
+                console.warn(
+                  'Could not generate JWT after calling setUserID. Please try calling setUserID again.'
+                );
+              }
+              return Promise.reject(e);
+            });
+        } catch (e) {
+          /* failed to create a new user. Just silently resolve */
+          return Promise.resolve();
         }
       } catch (error) {
         // here we will not sync events but just bubble up error of merge

--- a/src/commerce/commerce.test.ts
+++ b/src/commerce/commerce.test.ts
@@ -7,8 +7,15 @@ import { setTypeOfAuthForTestingOnly } from '../authorization';
 
 const mockRequest = new MockAdapter(baseAxiosRequest);
 
+const localStorageMock = {
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn()
+};
+
 describe('Users Requests', () => {
   beforeEach(() => {
+    (global as any).localStorage = localStorageMock;
     setTypeOfAuthForTestingOnly('email');
   });
   it('should set params and return the correct payload for updateCart', async () => {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -286,6 +286,7 @@ export const SHARED_PREFS_CRITERIA = 'criteria';
 export const SHARED_PREFS_ANON_SESSIONS = 'itbl_anon_sessions';
 export const SHARED_PREF_ANON_USER_ID = 'anon_userId';
 export const SHARED_PREF_ANON_USAGE_TRACKED = 'itbl_anonymous_usage_tracked';
+export const SHARED_PREF_USER_TOKEN = 'itbl_auth_token';
 
 export const KEY_EVENT_NAME = 'eventName';
 export const KEY_CREATED_AT = 'createdAt';

--- a/src/events/events.test.ts
+++ b/src/events/events.test.ts
@@ -62,6 +62,7 @@ describe('Events Requests', () => {
   });
 
   beforeEach(() => {
+    (global as any).localStorage = localStorageMock;
     setTypeOfAuthForTestingOnly('userID');
   });
 

--- a/src/request.ts
+++ b/src/request.ts
@@ -13,6 +13,7 @@ import {
 import { IterablePromise, IterableResponse } from './types';
 import { config } from './utils/config';
 import { getTypeOfAuth } from './utils/typeOfAuth';
+import { AuthorizationToken } from './authorization';
 
 interface ExtendedRequestConfig extends AxiosRequestConfig {
   validation?: {
@@ -65,12 +66,17 @@ export const baseIterableRequest = <T = any>(
       ? EU_ITERABLE_API
       : config.getConfig('baseURL');
 
+    const authorizationToken = new AuthorizationToken();
+    const JWT = authorizationToken.getToken();
+    const Authorization = JWT ? `Bearer ${JWT}` : undefined;
+
     return baseAxiosRequest({
       ...payload,
       baseURL,
       headers: {
         ...payload.headers,
-        ...STATIC_HEADERS
+        ...STATIC_HEADERS,
+        Authorization
       },
       paramsSerializer: (params) =>
         qs.stringify(params, { arrayFormat: 'repeat' })

--- a/src/request.ts
+++ b/src/request.ts
@@ -13,7 +13,7 @@ import {
 import { IterablePromise, IterableResponse } from './types';
 import { config } from './utils/config';
 import { getTypeOfAuth } from './utils/typeOfAuth';
-import { AuthorizationToken } from './authorization';
+import AuthorizationToken from './utils/authorizationToken';
 
 interface ExtendedRequestConfig extends AxiosRequestConfig {
   validation?: {

--- a/src/users/users.test.ts
+++ b/src/users/users.test.ts
@@ -7,8 +7,15 @@ import { setTypeOfAuthForTestingOnly } from '../authorization';
 
 const mockRequest = new MockAdapter(baseAxiosRequest);
 
+const localStorageMock = {
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn()
+};
+
 describe('Users Requests', () => {
   beforeEach(() => {
+    (global as any).localStorage = localStorageMock;
     setTypeOfAuthForTestingOnly('email');
   });
   it('should set params and return the correct payload for updateUser', async () => {

--- a/src/utils/authorizationToken.ts
+++ b/src/utils/authorizationToken.ts
@@ -1,0 +1,21 @@
+import { SHARED_PREF_USER_TOKEN } from '../constants';
+
+class AuthorizationToken {
+  public token: string | null = null;
+
+  setToken(token: string) {
+    this.token = token;
+    localStorage.setItem(SHARED_PREF_USER_TOKEN, token);
+  }
+
+  getToken(): string | null {
+    return this.token || localStorage.getItem(SHARED_PREF_USER_TOKEN);
+  }
+
+  clearToken() {
+    this.token = '';
+    localStorage.removeItem(SHARED_PREF_USER_TOKEN);
+  }
+}
+
+export default AuthorizationToken;


### PR DESCRIPTION
## JIRA Ticket(s) if any

* [MOB-9703](https://iterable.atlassian.net/browse/MOB-9703)

## Description
Update SDK to support fetching a new JWT to use for the destinationUserId / destinationEmail when calling merge

## Test Steps
Video attached to the ticket, See a JIRA ticket for the video

[MOB-9703]: https://iterable.atlassian.net/browse/MOB-9703?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ