### PR TITLE
[MOB-10121]: Don't error on anon track events

### DIFF
--- a/src/authorization/authorization.test.ts
+++ b/src/authorization/authorization.test.ts
@@ -475,7 +475,7 @@ describe('User Identification', () => {
         expect(JSON.parse(userResponse && userResponse.config.data).email).toBe(
           'hello@gmail.com'
         );
-        expect(JSON.parse(trackResponse.config.data).email).toBe(
+        expect(JSON.parse(trackResponse?.config.data).email).toBe(
           'hello@gmail.com'
         );
       });
@@ -508,10 +508,10 @@ describe('User Identification', () => {
 
         const cartResponse = await updateCart({ items: [] });
         const trackResponse = await trackPurchase({ items: [], total: 100 });
-        expect(JSON.parse(cartResponse.config.data).user.email).toBe(
+        expect(JSON.parse(cartResponse?.config.data).user.email).toBe(
           'hello@gmail.com'
         );
-        expect(JSON.parse(trackResponse.config.data).user.email).toBe(
+        expect(JSON.parse(trackResponse?.config.data).user.email).toBe(
           'hello@gmail.com'
         );
       });
@@ -626,7 +626,7 @@ describe('User Identification', () => {
         expect(
           JSON.parse(userResponse && userResponse.config.data).userId
         ).toBe('999');
-        expect(JSON.parse(trackResponse.config.data).userId).toBe('999');
+        expect(JSON.parse(trackResponse?.config.data).userId).toBe('999');
       });
 
       it('adds currentUserId body to endpoint that need an currentUserId as a body', async () => {
@@ -654,8 +654,8 @@ describe('User Identification', () => {
 
         const cartResponse = await updateCart({ items: [] });
         const trackResponse = await trackPurchase({ items: [], total: 100 });
-        expect(JSON.parse(cartResponse.config.data).user.userId).toBe('999');
-        expect(JSON.parse(trackResponse.config.data).user.userId).toBe('999');
+        expect(JSON.parse(cartResponse?.config.data).user.userId).toBe('999');
+        expect(JSON.parse(trackResponse?.config.data).user.userId).toBe('999');
       });
 
       it('adds no userId body or header information to unrelated endpoints', async () => {
@@ -813,7 +813,7 @@ describe('User Identification', () => {
         expect(JSON.parse(userResponse && userResponse.config.data).email).toBe(
           'hello@gmail.com'
         );
-        expect(JSON.parse(trackResponse.config.data).email).toBe(
+        expect(JSON.parse(trackResponse?.config.data).email).toBe(
           'hello@gmail.com'
         );
       });
@@ -850,10 +850,10 @@ describe('User Identification', () => {
 
         const cartResponse = await updateCart({ items: [] });
         const trackResponse = await trackPurchase({ items: [], total: 100 });
-        expect(JSON.parse(cartResponse.config.data).user.email).toBe(
+        expect(JSON.parse(cartResponse?.config.data).user.email).toBe(
           'hello@gmail.com'
         );
-        expect(JSON.parse(trackResponse.config.data).user.email).toBe(
+        expect(JSON.parse(trackResponse?.config.data).user.email).toBe(
           'hello@gmail.com'
         );
       });
@@ -980,7 +980,7 @@ describe('User Identification', () => {
         expect(
           JSON.parse(userResponse && userResponse.config.data).userId
         ).toBe('999');
-        expect(JSON.parse(trackResponse.config.data).userId).toBe('999');
+        expect(JSON.parse(trackResponse?.config.data).userId).toBe('999');
       });
 
       it('adds currentUserId body to endpoint that need an currentUserId as a body', async () => {
@@ -1012,8 +1012,8 @@ describe('User Identification', () => {
 
         const cartResponse = await updateCart({ items: [] });
         const trackResponse = await trackPurchase({ items: [], total: 100 });
-        expect(JSON.parse(cartResponse.config.data).user.userId).toBe('999');
-        expect(JSON.parse(trackResponse.config.data).user.userId).toBe('999');
+        expect(JSON.parse(cartResponse?.config.data).user.userId).toBe('999');
+        expect(JSON.parse(trackResponse?.config.data).user.userId).toBe('999');
       });
 
       it('adds no userId body or header information to unrelated endpoints', async () => {

--- a/src/commerce/commerce.test.ts
+++ b/src/commerce/commerce.test.ts
@@ -34,7 +34,7 @@ describe('Users Requests', () => {
       ]
     });
 
-    expect(JSON.parse(response.config.data).items).toEqual([
+    expect(JSON.parse(response?.config.data).items).toEqual([
       {
         id: 'fdsafds',
         name: 'banana',
@@ -42,10 +42,10 @@ describe('Users Requests', () => {
         price: 12
       }
     ]);
-    expect(JSON.parse(response.config.data).user.preferUserId).toBe(true);
+    expect(JSON.parse(response?.config.data).user.preferUserId).toBe(true);
     // expect(response.config.headers['SDK-Version']).toBe(SDK_VERSION);
     // expect(response.config.headers['SDK-Platform']).toBe(WEB_PLATFORM);
-    expect(response.data.msg).toBe('hello');
+    expect(response?.data.msg).toBe('hello');
   });
 
   it('should reject updateCart on bad params', async () => {
@@ -87,10 +87,10 @@ describe('Users Requests', () => {
       total: 100
     });
 
-    expect(JSON.parse(response.config.data).total).toBe(100);
-    expect(JSON.parse(response.config.data).items).toEqual([]);
-    expect(JSON.parse(response.config.data).user.preferUserId).toBe(true);
-    expect(response.data.msg).toBe('hello');
+    expect(JSON.parse(response?.config.data).total).toBe(100);
+    expect(JSON.parse(response?.config.data).items).toEqual([]);
+    expect(JSON.parse(response?.config.data).user.preferUserId).toBe(true);
+    expect(response?.data.msg).toBe('hello');
   });
 
   it('should not allow a passed userId or email for API methods', async () => {
@@ -117,10 +117,10 @@ describe('Users Requests', () => {
       total: 100
     } as any);
 
-    expect(JSON.parse(updateResponse.config.data).user.email).toBeUndefined();
-    expect(JSON.parse(updateResponse.config.data).user.userId).toBeUndefined();
-    expect(JSON.parse(trackResponse.config.data).user.email).toBeUndefined();
-    expect(JSON.parse(trackResponse.config.data).user.userId).toBeUndefined();
+    expect(JSON.parse(updateResponse?.config.data).user.email).toBeUndefined();
+    expect(JSON.parse(updateResponse?.config.data).user.userId).toBeUndefined();
+    expect(JSON.parse(trackResponse?.config.data).user.email).toBeUndefined();
+    expect(JSON.parse(trackResponse?.config.data).user.userId).toBeUndefined();
   });
 
   it('should reject updateCart on bad params', async () => {

--- a/src/commerce/commerce.ts
+++ b/src/commerce/commerce.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-param-reassign */
-import { ENDPOINTS } from '../constants';
+import { AUA_WARNING_MESSAGE, ENDPOINTS } from '../constants';
 import { baseIterableRequest } from '../request';
 import { TrackPurchaseRequestParams, UpdateCartRequestParams } from './types';
 import { IterableResponse } from '../types';
@@ -16,7 +16,7 @@ export const updateCart = (payload: UpdateCartRequestParams) => {
   if (canTrackAnonUser()) {
     const anonymousUserEventManager = new AnonymousUserEventManager();
     anonymousUserEventManager.trackAnonUpdateCart(payload);
-    return Promise.resolve();
+    return Promise.reject(AUA_WARNING_MESSAGE).catch((e) => console.warn(e));
   }
 
   return baseIterableRequest<IterableResponse>({
@@ -44,7 +44,7 @@ export const trackPurchase = (payload: TrackPurchaseRequestParams) => {
   if (canTrackAnonUser()) {
     const anonymousUserEventManager = new AnonymousUserEventManager();
     anonymousUserEventManager.trackAnonPurchaseEvent(payload);
-    return Promise.resolve();
+    return Promise.reject(AUA_WARNING_MESSAGE).catch((e) => console.warn(e));
   }
 
   return baseIterableRequest<IterableResponse>({

--- a/src/commerce/commerce.ts
+++ b/src/commerce/commerce.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-param-reassign */
-import { INITIALIZE_ERROR, ENDPOINTS } from '../constants';
+import { ENDPOINTS } from '../constants';
 import { baseIterableRequest } from '../request';
 import { TrackPurchaseRequestParams, UpdateCartRequestParams } from './types';
 import { IterableResponse } from '../types';
@@ -16,7 +16,7 @@ export const updateCart = (payload: UpdateCartRequestParams) => {
   if (canTrackAnonUser()) {
     const anonymousUserEventManager = new AnonymousUserEventManager();
     anonymousUserEventManager.trackAnonUpdateCart(payload);
-    return Promise.reject(INITIALIZE_ERROR);
+    return Promise.resolve();
   }
 
   return baseIterableRequest<IterableResponse>({
@@ -44,7 +44,7 @@ export const trackPurchase = (payload: TrackPurchaseRequestParams) => {
   if (canTrackAnonUser()) {
     const anonymousUserEventManager = new AnonymousUserEventManager();
     anonymousUserEventManager.trackAnonPurchaseEvent(payload);
-    return Promise.reject(INITIALIZE_ERROR);
+    return Promise.resolve();
   }
 
   return baseIterableRequest<IterableResponse>({

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -311,3 +311,7 @@ export const MERGE_SUCCESSFULL = 'MERGE_SUCCESSFULL';
 export const INITIALIZE_ERROR = new Error(
   'Iterable SDK must be initialized with an API key and user email/userId before calling SDK methods'
 );
+
+export const AUA_WARNING_MESSAGE = new Error(
+  'Event tracked locally using AUA.'
+);

--- a/src/events/events.test.ts
+++ b/src/events/events.test.ts
@@ -69,8 +69,8 @@ describe('Events Requests', () => {
   it('return the correct payload for track', async () => {
     const response = await track({ eventName: 'test' });
 
-    expect(JSON.parse(response.config.data).eventName).toBe('test');
-    expect(response.data.msg).toBe('hello');
+    expect(JSON.parse(response?.config.data).eventName).toBe('test');
+    expect(response?.data.msg).toBe('hello');
   });
 
   it('should reject track on bad params', async () => {
@@ -465,10 +465,10 @@ describe('Events Requests', () => {
       appPackageName: 'my-lil-site'
     } as any);
 
-    expect(JSON.parse(trackResponse.config.data).email).toBeUndefined();
-    expect(JSON.parse(trackResponse.config.data).userId).toBeUndefined();
+    expect(JSON.parse(trackResponse?.config.data).email).toBeUndefined();
+    expect(JSON.parse(trackResponse?.config.data).userId).toBeUndefined();
     expect(
-      JSON.parse(trackResponse.config.data).deviceInfo.appPackageName
+      JSON.parse(trackResponse?.config.data).deviceInfo.appPackageName
     ).toBe('my-lil-site');
 
     expect(JSON.parse(trackClickResponse.config.data).email).toBeUndefined();

--- a/src/events/events.ts
+++ b/src/events/events.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-param-reassign */
-import { INITIALIZE_ERROR, ENDPOINTS } from '../constants';
+import { ENDPOINTS } from '../constants';
 import { baseIterableRequest } from '../request';
 import { InAppTrackRequestParams } from './inapp/types';
 import { IterableResponse } from '../types';
@@ -14,7 +14,7 @@ export const track = (payload: InAppTrackRequestParams) => {
   if (canTrackAnonUser()) {
     const anonymousUserEventManager = new AnonymousUserEventManager();
     anonymousUserEventManager.trackAnonEvent(payload);
-    return Promise.reject(INITIALIZE_ERROR);
+    return Promise.resolve();
   }
   return baseIterableRequest<IterableResponse>({
     method: 'POST',

--- a/src/events/events.ts
+++ b/src/events/events.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-param-reassign */
-import { ENDPOINTS } from '../constants';
+import { ENDPOINTS, AUA_WARNING_MESSAGE } from '../constants';
 import { baseIterableRequest } from '../request';
 import { InAppTrackRequestParams } from './inapp/types';
 import { IterableResponse } from '../types';
@@ -14,7 +14,7 @@ export const track = (payload: InAppTrackRequestParams) => {
   if (canTrackAnonUser()) {
     const anonymousUserEventManager = new AnonymousUserEventManager();
     anonymousUserEventManager.trackAnonEvent(payload);
-    return Promise.resolve();
+    return Promise.reject(AUA_WARNING_MESSAGE).catch((e) => console.warn(e));
   }
   return baseIterableRequest<IterableResponse>({
     method: 'POST',

--- a/src/users/users.test.ts
+++ b/src/users/users.test.ts
@@ -192,8 +192,8 @@ describe('Users Requests', () => {
       userId: '1234'
     } as any);
 
-    expect(JSON.parse(updateResponse.config.data).email).toBeUndefined();
-    expect(JSON.parse(updateResponse.config.data).userId).toBeUndefined();
+    expect(JSON.parse(updateResponse?.config.data).email).toBeUndefined();
+    expect(JSON.parse(updateResponse?.config.data).userId).toBeUndefined();
     expect(JSON.parse(subsResponse.config.data).email).toBeUndefined();
     expect(JSON.parse(subsResponse.config.data).userId).toBeUndefined();
   });

--- a/src/users/users.ts
+++ b/src/users/users.ts
@@ -6,7 +6,7 @@ import { UpdateSubscriptionParams, UpdateUserParams } from './types';
 import { updateSubscriptionsSchema, updateUserSchema } from './users.schema';
 import { AnonymousUserEventManager } from '../anonymousUserTracking/anonymousUserEventManager';
 import { canTrackAnonUser } from '../utils/commonFunctions';
-import { INITIALIZE_ERROR, ENDPOINTS } from '../constants';
+import { ENDPOINTS } from '../constants';
 
 export const updateUserEmail = (newEmail: string) =>
   baseIterableRequest<IterableResponse>({
@@ -31,7 +31,7 @@ export const updateUser = (payloadParam: UpdateUserParams = {}) => {
   if (canTrackAnonUser()) {
     const anonymousUserEventManager = new AnonymousUserEventManager();
     anonymousUserEventManager.trackAnonUpdateUser(payload);
-    return Promise.reject(INITIALIZE_ERROR);
+    return Promise.resolve();
   }
   return baseIterableRequest<IterableResponse>({
     method: 'POST',

--- a/src/users/users.ts
+++ b/src/users/users.ts
@@ -6,7 +6,7 @@ import { UpdateSubscriptionParams, UpdateUserParams } from './types';
 import { updateSubscriptionsSchema, updateUserSchema } from './users.schema';
 import { AnonymousUserEventManager } from '../anonymousUserTracking/anonymousUserEventManager';
 import { canTrackAnonUser } from '../utils/commonFunctions';
-import { ENDPOINTS } from '../constants';
+import { ENDPOINTS, AUA_WARNING_MESSAGE } from '../constants';
 
 export const updateUserEmail = (newEmail: string) =>
   baseIterableRequest<IterableResponse>({
@@ -31,7 +31,7 @@ export const updateUser = (payloadParam: UpdateUserParams = {}) => {
   if (canTrackAnonUser()) {
     const anonymousUserEventManager = new AnonymousUserEventManager();
     anonymousUserEventManager.trackAnonUpdateUser(payload);
-    return Promise.resolve();
+    return Promise.reject(AUA_WARNING_MESSAGE).catch((e) => console.warn(e));
   }
   return baseIterableRequest<IterableResponse>({
     method: 'POST',


### PR DESCRIPTION
## JIRA Ticket(s) if any

* [MOB-10121](https://iterable.atlassian.net/browse/MOB-10121)

## Description
We are currently returning a resolved error when anon track events take place. This fixes that by simply `resolving` instead of `rejecting`

## Test Steps

[MOB-10121]: https://iterable.atlassian.net/browse/MOB-10121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ