### PR TITLE
[MOB-10123]: Clear Anon Data When Replay is False

### DIFF
--- a/src/anonymousUserTracking/tests/userMergeScenarios.test.ts
+++ b/src/anonymousUserTracking/tests/userMergeScenarios.test.ts
@@ -136,7 +136,7 @@ describe('UserMergeScenariosTests', () => {
         (call) => call[0] === SHARED_PREFS_EVENT_LIST_KEY
       );
       // count 2 is because we want to remove the anon user and remove anon details
-      expect(removeItemCalls.length).toBe(1);
+      expect(removeItemCalls.length).toBe(2);
       const mergePostRequestData = mockRequest.history.post.find(
         (req) => req.url === ENDPOINT_MERGE_USER
       );

--- a/src/anonymousUserTracking/tests/userMergeScenarios.test.ts
+++ b/src/anonymousUserTracking/tests/userMergeScenarios.test.ts
@@ -135,8 +135,7 @@ describe('UserMergeScenariosTests', () => {
       const removeItemCalls = localStorageMock.removeItem.mock.calls.filter(
         (call) => call[0] === SHARED_PREFS_EVENT_LIST_KEY
       );
-      // count 1 means it did not remove item and so syncEvents was NOT called
-      // because removeItem gets called one time for the key in case of logout
+      // count 2 is because we want to remove the anon user and remove anon details
       expect(removeItemCalls.length).toBe(1);
       const mergePostRequestData = mockRequest.history.post.find(
         (req) => req.url === ENDPOINT_MERGE_USER
@@ -175,7 +174,6 @@ describe('UserMergeScenariosTests', () => {
         (call) => call[0] === SHARED_PREFS_EVENT_LIST_KEY
       );
       // count 2 means it removed items and so syncEvents was called
-
       // because removeItem gets called one time for
       // the key in case of logout and 2nd time on syncevents
       expect(removeItemCalls.length).toBe(2);
@@ -574,9 +572,8 @@ describe('UserMergeScenariosTests', () => {
       const removeItemCalls = localStorageMock.removeItem.mock.calls.filter(
         (call) => call[0] === SHARED_PREFS_EVENT_LIST_KEY
       );
-      // count 1 means it did not remove item and so syncEvents was NOT called
-      // because removeItem gets called one time for the key in case of logout
-      expect(removeItemCalls.length).toBe(1);
+      // count 2 is because we want to remove the anon user and remove anon details
+      expect(removeItemCalls.length).toBe(2);
       const mergePostRequestData = mockRequest.history.post.find(
         (req) => req.url === ENDPOINT_MERGE_USER
       );

--- a/src/authorization/authorization.ts
+++ b/src/authorization/authorization.ts
@@ -212,7 +212,7 @@ const initializeEmailUser = (email: string) => {
   clearAnonymousUser();
 };
 
- const syncEvents = () => {
+const syncEvents = () => {
   if (config.getConfig('enableAnonActivation')) {
     anonUserManager.syncEvents();
   }

--- a/src/authorization/authorization.ts
+++ b/src/authorization/authorization.ts
@@ -487,8 +487,9 @@ export function initialize(
             initializeEmailUser(email);
             if (replay) {
               syncEvents();
+            } else {
+              anonUserManager.removeAnonSessionCriteriaData();
             }
-            anonUserManager.removeAnonSessionCriteriaData();
             return Promise.resolve();
           }
         } catch (error) {
@@ -516,8 +517,9 @@ export function initialize(
             initializeUserId(userId);
             if (replay) {
               syncEvents();
+            } else {
+              anonUserManager.removeAnonSessionCriteriaData();
             }
-            anonUserManager.removeAnonSessionCriteriaData();
             return Promise.resolve();
           }
         } catch (error) {
@@ -867,8 +869,9 @@ export function initialize(
                 initializeEmailUser(email);
                 if (replay) {
                   syncEvents();
+                } else {
+                  anonUserManager.removeAnonSessionCriteriaData();
                 }
-                anonUserManager.removeAnonSessionCriteriaData();
                 return token;
               }
             })
@@ -911,8 +914,9 @@ export function initialize(
                 initializeUserId(userId);
                 if (replay) {
                   syncEvents();
+                } else {
+                  anonUserManager.removeAnonSessionCriteriaData();
                 }
-                anonUserManager.removeAnonSessionCriteriaData();
                 return token;
               }
             })

--- a/src/authorization/authorization.ts
+++ b/src/authorization/authorization.ts
@@ -212,7 +212,7 @@ const initializeEmailUser = (email: string) => {
   clearAnonymousUser();
 };
 
-const syncEvents = () => {
+ const syncEvents = () => {
   if (config.getConfig('enableAnonActivation')) {
     anonUserManager.syncEvents();
   }
@@ -488,6 +488,7 @@ export function initialize(
             if (replay) {
               syncEvents();
             }
+            anonUserManager.removeAnonSessionCriteriaData();
             return Promise.resolve();
           }
         } catch (error) {
@@ -516,6 +517,7 @@ export function initialize(
             if (replay) {
               syncEvents();
             }
+            anonUserManager.removeAnonSessionCriteriaData();
             return Promise.resolve();
           }
         } catch (error) {
@@ -866,6 +868,7 @@ export function initialize(
                 if (replay) {
                   syncEvents();
                 }
+                anonUserManager.removeAnonSessionCriteriaData();
                 return token;
               }
             })
@@ -909,6 +912,7 @@ export function initialize(
                 if (replay) {
                   syncEvents();
                 }
+                anonUserManager.removeAnonSessionCriteriaData();
                 return token;
               }
             })


### PR DESCRIPTION
## JIRA Ticket(s) if any

* [MOB-10123](https://iterable.atlassian.net/browse/MOB-10123)

## Description
We should clear anon data on login even if `replayOnAnonToKnown` is set to false. `syncEvents` already handles the clearing of the data for us. 

## Test Steps

[MOB-10123]: https://iterable.atlassian.net/browse/MOB-10123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ