### PR TITLE
[MOB-11427] Add maxWidth to getInAppMessages payload

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-  "typescript.tsdk": "node_modules/typescript/lib",
+	"typescript.tsdk": "node_modules/typescript/lib",
+	"editor.defaultFormatter": "dbaeumer.vscode-eslint"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,3 @@
 {
-	"typescript.tsdk": "node_modules/typescript/lib",
-	"editor.defaultFormatter": "dbaeumer.vscode-eslint"
+  "typescript.tsdk": "node_modules/typescript/lib",
 }

--- a/README.md
+++ b/README.md
@@ -2360,12 +2360,21 @@ For example:
 - If your in-app is positioned in the center and your browser if at 700px, your
   in-app message will grow to take up 100% of the screen.
 
-This chart also implies that yout in-app message is taking 100% of its container. 
+This chart also implies that your in-app message is taking 100% of its container. 
 Your results may vary if you add, for example, a `max-width: 200px` CSS rule to 
-your message HTML. 
+your message HTML, as it would not apply to the enclosing iframe.
 
-Regardless of how you write your CSS, these rules take effect. So, when creating
-an in-app message, it is best to stick with percentage-based CSS widths.
+For Center, Top-Right, and Bottom-Right positions only, if you need to set a custom
+max-width rule for your message, you can include `maxWidth` in your getInAppMessages
+payload like so:
+
+```ts
+const { request } = getInAppMessages({
+  count: 20,
+  packageName: 'my-website',
+  maxWidth: '300px'
+});
+```
 
 ## How do I add custom callbacks to handle link clicks on in-app and embedded messages?
 

--- a/README.md
+++ b/README.md
@@ -2364,17 +2364,20 @@ This chart also implies that your in-app message is taking 100% of its container
 Your results may vary if you add, for example, a `max-width: 200px` CSS rule to 
 your message HTML, as it would not apply to the enclosing iframe.
 
-For Center, Top-Right, and Bottom-Right positions only, if you need to set a custom
-max-width rule for your message, you can include `maxWidth` in your getInAppMessages
-payload like so:
+For Center, Top-Right, and Bottom-Right positions, you can set a custom `maxWidth`
+by including it in your getInAppMessages payload like this:
 
 ```ts
 const { request } = getInAppMessages({
   count: 20,
   packageName: 'my-website',
-  maxWidth: '300px'
+  maxWidth: '900px'
 });
 ```
+
+`maxWidth` accepts any valid CSS max-width value (e.g., px, em, %, ch).
+It is optional—-most in-app messages render well with default sizing, so set it
+only if needed for your use case.
 
 ## How do I add custom callbacks to handle link clicks on in-app and embedded messages?
 

--- a/src/inapp/inapp.ts
+++ b/src/inapp/inapp.ts
@@ -91,6 +91,7 @@ export function getInAppMessages(
   delete dupedPayload.animationDuration;
   delete dupedPayload.handleLinks;
   delete dupedPayload.closeButton;
+  delete dupedPayload.maxWidth;
 
   if (options?.display) {
     addStyleSheet(document, ANIMATION_STYLESHEET(payload.animationDuration));
@@ -166,7 +167,8 @@ export function getInAppMessages(
           payload.onOpenScreenReaderMessage || 'in-app iframe message opened',
           payload.topOffset,
           payload.bottomOffset,
-          payload.rightOffset
+          payload.rightOffset,
+          payload.maxWidth
         ).then((activeIframe) => {
           const activeIframeDocument = activeIframe?.contentDocument;
 

--- a/src/inapp/inapp.ts
+++ b/src/inapp/inapp.ts
@@ -160,16 +160,17 @@ export function getInAppMessages(
         };
 
         /* add the message's html to an iframe and paint it to the DOM */
-        return paintIFrame(
-          activeMessage.content.html as string,
-          messagePosition,
+        return paintIFrame({
+          html: activeMessage.content.html as string,
+          position: messagePosition,
           shouldAnimate,
-          payload.onOpenScreenReaderMessage || 'in-app iframe message opened',
-          payload.topOffset,
-          payload.bottomOffset,
-          payload.rightOffset,
-          payload.maxWidth
-        ).then((activeIframe) => {
+          srMessage:
+            payload.onOpenScreenReaderMessage || 'in-app iframe message opened',
+          topOffset: payload.topOffset,
+          bottomOffset: payload.bottomOffset,
+          rightOffset: payload.rightOffset,
+          maxWidth: payload.maxWidth
+        }).then((activeIframe) => {
           const activeIframeDocument = activeIframe?.contentDocument;
 
           const throttledResize =

--- a/src/inapp/tests/utils.test.ts
+++ b/src/inapp/tests/utils.test.ts
@@ -747,14 +747,27 @@ describe('Utils', () => {
         const iframe = await paintIFrame({
           html: mockMarkup,
           position: DisplayPosition.Center,
-          srMessage: 'hi',
-          maxWidth: '350px'
+          srMessage: 'hi'
         });
         jest.advanceTimersByTime(2000);
 
         /* speed up time to past the setTimeout */
         const styles = getComputedStyle(iframe);
-        checkStyles(styles, { maxWidth: '350px' });
+        checkStyles(styles);
+      });
+
+      it('should paint the iframe with custom maxWidth', async () => {
+        const { Center, TopRight, BottomRight } = DisplayPosition;
+        [Center, TopRight, BottomRight].forEach(async (position) => {
+          const iframe = await paintIFrame({
+            html: mockMarkup,
+            position,
+            maxWidth: '350px'
+          });
+          jest.advanceTimersByTime(2000);
+          const styles = getComputedStyle(iframe);
+          expect(styles.maxWidth).toBe('350px');
+        });
       });
 
       it('should paint the iframe in the top-right of the screen', async () => {

--- a/src/inapp/tests/utils.test.ts
+++ b/src/inapp/tests/utils.test.ts
@@ -717,147 +717,144 @@ describe('Utils', () => {
     });
 
     describe('painting the iframe', () => {
+      const defaultStyles = {
+        position: 'fixed',
+        left: '0%',
+        right: '0%',
+        top: '0%',
+        bottom: '0%',
+        zIndex: '9999',
+        width: '100%',
+        maxHeight: '95vh',
+        maxWidth: '100%'
+      };
+
+      const checkStyles = (
+        styles: CSSStyleDeclaration,
+        overrides?: Partial<typeof defaultStyles> & { height?: string }
+      ) => {
+        Object.entries(defaultStyles).forEach(([key, value]) => {
+          const styleValue = styles[key as keyof typeof styles];
+          expect(styleValue).toBe(
+            overrides && key in overrides
+              ? overrides[key as keyof typeof overrides]
+              : value
+          );
+        });
+      };
+
       it('should paint the iframe in the center of the screen', async () => {
-        const iframe = await paintIFrame(
-          mockMarkup,
-          DisplayPosition.Center,
-          false,
-          'hi'
-        );
+        const iframe = await paintIFrame({
+          html: mockMarkup,
+          position: DisplayPosition.Center,
+          srMessage: 'hi',
+          maxWidth: '350px'
+        });
         jest.advanceTimersByTime(2000);
 
         /* speed up time to past the setTimeout */
         const styles = getComputedStyle(iframe);
-        expect(styles.position).toBe('fixed');
-        expect(styles.left).toBe('0%');
-        expect(styles.right).toBe('0%');
-        expect(styles.top).toBe('0%');
-        expect(styles.bottom).toBe('0%');
-        expect(styles.zIndex).toBe('9999');
-        expect(styles.width).toBe('100%');
-        expect(styles.maxHeight).toBe('95vh');
+        checkStyles(styles, { maxWidth: '350px' });
       });
 
       it('should paint the iframe in the top-right of the screen', async () => {
-        const iframe = await paintIFrame(
-          mockMarkup,
-          DisplayPosition.TopRight,
-          false,
-          'hi'
-        );
+        const iframe = await paintIFrame({
+          html: mockMarkup,
+          position: DisplayPosition.TopRight,
+          srMessage: 'hi'
+        });
         jest.advanceTimersByTime(2000);
 
         /* speed up time to past the setTimeout */
         const styles = getComputedStyle(iframe);
-        expect(styles.position).toBe('fixed');
-        expect(styles.left).toBe('');
-        expect(styles.right).toBe('0%');
-        expect(styles.top).toBe('0%');
-        expect(styles.bottom).toBe('');
-        expect(styles.zIndex).toBe('9999');
-        expect(styles.width).toBe('100%');
-        expect(styles.maxHeight).toBe('95vh');
+        checkStyles(styles, { left: '', bottom: '' });
       });
 
       it('should paint the iframe in the bottom-right of the screen', async () => {
-        const iframe = await paintIFrame(
-          mockMarkup,
-          DisplayPosition.BottomRight,
-          false,
-          'hi'
-        );
+        const iframe = await paintIFrame({
+          html: mockMarkup,
+          position: DisplayPosition.BottomRight,
+          srMessage: 'hi'
+        });
         jest.advanceTimersByTime(2000);
 
         /* speed up time to past the setTimeout */
         const styles = getComputedStyle(iframe);
-        expect(styles.position).toBe('fixed');
-        expect(styles.left).toBe('');
-        expect(styles.right).toBe('0%');
-        expect(styles.bottom).toBe('0%');
-        expect(styles.top).toBe('');
-        expect(styles.zIndex).toBe('9999');
-        expect(styles.width).toBe('100%');
-        expect(styles.maxHeight).toBe('95vh');
+        checkStyles(styles, { left: '', top: '' });
       });
 
       it('should paint the iframe full-screen', async () => {
-        const iframe = await paintIFrame(
-          mockMarkup,
-          DisplayPosition.Full,
-          false,
-          ''
-        );
+        const iframe = await paintIFrame({
+          html: mockMarkup,
+          position: DisplayPosition.Full
+        });
         jest.advanceTimersByTime(2000);
 
         /* speed up time to past the setTimeout */
         const styles = getComputedStyle(iframe);
-        expect(styles.position).toBe('fixed');
-        expect(styles.left).toBe('0%');
-        expect(styles.right).toBe('');
-        expect(styles.bottom).toBe('');
-        expect(styles.top).toBe('0%');
-        expect(styles.zIndex).toBe('9999');
-        expect(styles.height).toBe('100%');
-        expect(styles.width).toBe('100%');
-        expect(styles.maxHeight).toBe('');
+        checkStyles(styles, {
+          right: '',
+          bottom: '',
+          height: '100%',
+          maxHeight: ''
+        });
       });
 
       it('should paint TopRight iframes with custom offsets', async () => {
-        const iframe = await paintIFrame(
-          mockMarkup,
-          DisplayPosition.TopRight,
-          false,
-          '',
-          '10px',
-          '10px',
-          '10px'
-        );
+        const iframe = await paintIFrame({
+          html: mockMarkup,
+          position: DisplayPosition.TopRight,
+          topOffset: '10px',
+          bottomOffset: '10px',
+          rightOffset: '10px'
+        });
         jest.advanceTimersByTime(2000);
 
         /* speed up time to past the setTimeout */
         const styles = getComputedStyle(iframe);
-        expect(styles.position).toBe('fixed');
-        expect(styles.left).toBe('');
-        expect(styles.right).toBe('10px');
-        expect(styles.bottom).toBe('');
-        expect(styles.top).toBe('10px');
-        expect(styles.zIndex).toBe('9999');
-        expect(styles.width).toBe('100%');
-        expect(styles.maxHeight).toBe('95vh');
+        checkStyles(styles, {
+          left: '',
+          right: '10px',
+          bottom: '',
+          top: '10px'
+        });
       });
 
       it('should paint BottomRight iframes with custom offsets', async () => {
-        const iframe = await paintIFrame(
-          mockMarkup,
-          DisplayPosition.BottomRight,
-          false,
-          '',
-          '10px',
-          '10px',
-          '10px'
-        );
+        const iframe = await paintIFrame({
+          html: mockMarkup,
+          position: DisplayPosition.BottomRight,
+          topOffset: '10px',
+          bottomOffset: '10px',
+          rightOffset: '10px'
+        });
         jest.advanceTimersByTime(2000);
 
         /* speed up time to past the setTimeout */
         const styles = getComputedStyle(iframe);
-        expect(styles.position).toBe('fixed');
-        expect(styles.left).toBe('');
-        expect(styles.right).toBe('10px');
-        expect(styles.bottom).toBe('10px');
-        expect(styles.top).toBe('');
-        expect(styles.zIndex).toBe('9999');
-        expect(styles.width).toBe('100%');
-        expect(styles.maxHeight).toBe('95vh');
+        checkStyles(styles, {
+          left: '',
+          right: '10px',
+          bottom: '10px',
+          top: ''
+        });
       });
 
       it('should call srSpeak if screen reader text passed', async () => {
-        await paintIFrame(mockMarkup, DisplayPosition.Center, false, 'hi');
+        await paintIFrame({
+          html: mockMarkup,
+          position: DisplayPosition.Center,
+          srMessage: 'hi'
+        });
 
         expect((srSpeak as any).mock.calls.length).toBe(1);
       });
 
       it('should not call srSpeak if no screen reader text passed', async () => {
-        await paintIFrame(mockMarkup, DisplayPosition.Center, false);
+        await paintIFrame({
+          html: mockMarkup,
+          position: DisplayPosition.Center
+        });
 
         expect((srSpeak as any).mock.calls.length).toBe(0);
       });
@@ -869,6 +866,7 @@ describe('Utils', () => {
 
       expect(el.getAttribute('aria-label')).toBe('hello');
       expect(el.getAttribute('role')).toBe('button');
+      // eslint-disable-next-line no-script-url
       expect(el.getAttribute('href')).toBe('javascript:undefined');
     });
 

--- a/src/inapp/types.ts
+++ b/src/inapp/types.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-use-before-define */
 import { IterablePromise } from '../types';
 
 export enum CloseButtonPosition {
@@ -23,6 +22,65 @@ export enum DisplayPosition {
   BottomRight = 'BottomRight',
   Full = 'Full'
 }
+
+export interface InAppDisplaySetting {
+  percentage?: number;
+  displayOption?: string;
+}
+
+export interface WebInAppDisplaySettings {
+  position: DisplayPosition;
+}
+
+export interface InAppMessage {
+  messageId: string;
+  campaignId: number;
+  createdAt: number;
+  expiresAt: number;
+  content: {
+    payload?: Record<string, any>;
+    html: string | HTMLIFrameElement;
+    inAppDisplaySettings: {
+      top: InAppDisplaySetting;
+      right: InAppDisplaySetting;
+      left: InAppDisplaySetting;
+      bottom: InAppDisplaySetting;
+      bgColor?: { alpha: number; hex: string };
+      shouldAnimate?: boolean;
+    };
+    webInAppDisplaySettings: WebInAppDisplaySettings;
+  };
+  customPayload: Record<string, any>;
+  trigger: { type: string };
+  saveToInbox: boolean;
+  inboxMetadata: {
+    title: string;
+    subtitle: string;
+    icon: string;
+  };
+  priorityLevel: number;
+  read: boolean;
+}
+
+export type PaintIframeProps = {
+  /** html you want to paint to the DOM inside the iframe */
+  html: string;
+  /** screen position the message should appear in */
+  position: WebInAppDisplaySettings['position'];
+  /** if the in-app should animate in/out */
+  shouldAnimate?: boolean;
+  /** The message you want the screen reader to read when popping up the message */
+  srMessage?: string;
+  /** how many px or % buffer between the in-app message and the top of the screen */
+  topOffset?: string;
+  /** how many px or % buffer between the in-app message and the bottom of the screen */
+  bottomOffset?: string;
+  /** how many px or % buffer between the in-app message and the right of the screen */
+  rightOffset?: string;
+  /** An explicitly set max width for the in-app message.
+   * Only applies to `Center`, `TopRight`, and `BottomRight` positions. */
+  maxWidth?: string;
+};
 
 type CloseButton = {
   color?: string;
@@ -67,6 +125,10 @@ export interface InAppMessagesRequestParams extends SDKInAppMessagesParams {
   //  userId?: string
 }
 
+export interface InAppMessageResponse {
+  inAppMessages: Partial<InAppMessage>[];
+}
+
 export interface GetInAppMessagesResponse {
   pauseMessageStream: () => void;
   resumeMessageStream: () => Promise<HTMLIFrameElement | ''>;
@@ -78,55 +140,7 @@ export interface GetInAppMessagesResponse {
 
 export type CachedMessage = [string, InAppMessage];
 
-export interface InAppDisplaySetting {
-  percentage?: number;
-  displayOption?: string;
-}
-
-export interface WebInAppDisplaySettings {
-  position: DisplayPosition;
-}
-
 export type BrowserStorageEstimate = StorageEstimate & {
   /** usageDetails not supported in Safari */
   usageDetails?: { indexedDB?: number };
 };
-
-export interface InAppMessage {
-  messageId: string;
-  campaignId: number;
-  createdAt: number;
-  expiresAt: number;
-  content: {
-    payload?: Record<string, any>;
-    html: string | HTMLIFrameElement;
-    inAppDisplaySettings: {
-      top: InAppDisplaySetting;
-      right: InAppDisplaySetting;
-      left: InAppDisplaySetting;
-      bottom: InAppDisplaySetting;
-      bgColor?: {
-        alpha: number;
-        hex: string;
-      };
-      shouldAnimate?: boolean;
-    };
-    webInAppDisplaySettings: WebInAppDisplaySettings;
-  };
-  customPayload: Record<string, any>;
-  trigger: {
-    type: string;
-  };
-  saveToInbox: boolean;
-  inboxMetadata: {
-    title: string;
-    subtitle: string;
-    icon: string;
-  };
-  priorityLevel: number;
-  read: boolean;
-}
-
-export interface InAppMessageResponse {
-  inAppMessages: Partial<InAppMessage>[];
-}

--- a/src/inapp/types.ts
+++ b/src/inapp/types.ts
@@ -50,6 +50,9 @@ interface SDKInAppMessagesParams {
   closeButton?: CloseButton;
   /** messageId of the latest (i.e., most recent) message in the device's local cache */
   latestCachedMessageId?: string;
+  /** Set a default max-width style for message iframe.
+   * Only applies to `Center`, `TopRight`, and `BottomRight` positions. */
+  maxWidth?: string;
 }
 
 export interface InAppMessagesRequestParams extends SDKInAppMessagesParams {

--- a/src/inapp/utils.ts
+++ b/src/inapp/utils.ts
@@ -13,7 +13,7 @@ import {
 } from '../constants';
 import { WebInAppDisplaySettings } from '.';
 import { srSpeak } from '../utils/srSpeak';
-import { CloseButtonPosition, InAppMessage } from './types';
+import { CloseButtonPosition, InAppMessage, PaintIframeProps } from './types';
 
 interface Breakpoints {
   smMatches: boolean;
@@ -338,32 +338,17 @@ const unsetIframeBodyMargin = (iframe: HTMLIFrameElement) => {
   if (contentDocument && !margin) contentDocument.body.style.margin = '0px';
 };
 
-/**
- * Generates an iframe with the provided html and appends it to the DOM.
- *
- * @param html html you want to paint to the DOM inside the iframe
- * @param position screen position the message should appear in
- * @param shouldAnimate if the in-app should animate in/out
- * @param srMessage The message you want the screen reader to read when popping up the message
- * @param topOffset how many px or % buffer between the in-app message and the top of the screen
- * @param bottomOffset how many px or % buffer between the in-app message
- * and the bottom of the screen
- * @param rightOffset how many px or % buffer between the in-app message and the right of the screen
- * @param maxWidth An explicitly set max width for the in-app message.
- * Only applies to `Center`, `TopRight`, and `BottomRight` positions.
- *
- * @returns { HTMLIFrameElement }
- */
-export const paintIFrame = (
-  html: string,
-  position: WebInAppDisplaySettings['position'],
-  shouldAnimate?: boolean,
-  srMessage?: string,
-  topOffset?: string,
-  bottomOffset?: string,
-  rightOffset?: string,
-  maxWidth?: string
-): Promise<HTMLIFrameElement> =>
+/** Generates an iframe with the provided html and appends it to the DOM. */
+export const paintIFrame = ({
+  html,
+  position,
+  shouldAnimate,
+  srMessage,
+  topOffset,
+  bottomOffset,
+  rightOffset,
+  maxWidth
+}: PaintIframeProps): Promise<HTMLIFrameElement> =>
   new Promise((resolve: (value: HTMLIFrameElement) => void) => {
     const iframe = generateSecuredIFrame();
 

--- a/src/inapp/utils.ts
+++ b/src/inapp/utils.ts
@@ -339,6 +339,7 @@ const unsetIframeBodyMargin = (iframe: HTMLIFrameElement) => {
 };
 
 /**
+ * Generates an iframe with the provided html and appends it to the DOM.
  *
  * @param html html you want to paint to the DOM inside the iframe
  * @param position screen position the message should appear in
@@ -348,6 +349,8 @@ const unsetIframeBodyMargin = (iframe: HTMLIFrameElement) => {
  * @param bottomOffset how many px or % buffer between the in-app message
  * and the bottom of the screen
  * @param rightOffset how many px or % buffer between the in-app message and the right of the screen
+ * @param maxWidth An explicitly set max width for the in-app message.
+ * Only applies to `Center`, `TopRight`, and `BottomRight` positions.
  *
  * @returns { HTMLIFrameElement }
  */
@@ -358,7 +361,8 @@ export const paintIFrame = (
   srMessage?: string,
   topOffset?: string,
   bottomOffset?: string,
-  rightOffset?: string
+  rightOffset?: string,
+  maxWidth?: string
 ): Promise<HTMLIFrameElement> =>
   new Promise((resolve: (value: HTMLIFrameElement) => void) => {
     const iframe = generateSecuredIFrame();
@@ -423,7 +427,7 @@ export const paintIFrame = (
               position: fixed;
               border: none;
               margin: auto;
-              max-width: 100%;
+              max-width: ${maxWidth || '100%'};
               z-index: 9999;
               transform: translateX(150%);
               -webkit-transform: translateX(150%);
@@ -434,7 +438,7 @@ export const paintIFrame = (
               position: fixed;
               border: none;
               margin: auto;
-              max-width: 100%;
+              max-width: ${maxWidth || '100%'};
               z-index: 9999;
               width: ${width};
               height: ${iframe.style.height};


### PR DESCRIPTION
## JIRA Ticket(s) if any

* [MOB-11427](https://iterable.atlassian.net/browse/MOB-11427)

## Description

* Adds maxWidth as an optional parameter to be passed into getInAppMessages.

No maxWidth:
![Screenshot 2025-05-13 at 3 25 16 PM](https://github.com/user-attachments/assets/e3a7a59e-732d-4382-aa1d-c3f073514335)

With 300px maxWidth:
![Screenshot 2025-05-13 at 3 25 52 PM](https://github.com/user-attachments/assets/59b90f5c-36d6-42e9-81e4-77782c5c919e)


## Test Steps

* Verify that in-browser messages render properly without maxWidth param.
* Verify that in-browser messages render properly with maxWidth param (respects the max width set).

[MOB-11427]: https://iterable.atlassian.net/browse/MOB-11427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ