### PR TITLE
[MOB-11441] Bump high vulnerability dependency versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@pabra/sortby": "^1.0.1",
     "@types/ws": "8.5.4",
-    "axios": "^1.6.2",
+    "axios": "^1.9.0",
     "axios-mock-adapter": "^1.22.0",
     "buffer": "^6.0.3",
     "copy-webpack-plugin": "^11.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@ axios-mock-adapter@^1.22.0:
     fast-deep-equal "^3.1.3"
     is-buffer "^2.0.5"
 
-axios@^1.6.2:
-  version "1.7.4"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.4.tgz#4c8ded1b43683c8dd362973c393f3ede24052aa2"
-  integrity sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==
+axios@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.9.0.tgz#25534e3b72b54540077d33046f77e3b8d7081901"
+  integrity sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==
   dependencies:
     follow-redirects "^1.15.6"
     form-data "^4.0.0"


### PR DESCRIPTION
## JIRA Ticket(s) if any

* [MOB-11441](https://iterable.atlassian.net/browse/MOB-11441)

## Description

Bumps dependency version for `High` vulnerability dependencies.
* axios
* body-parser

## Test Steps

* All unit tests pass
* Renders basic in-browser message using react sample app

[MOB-11441]: https://iterable.atlassian.net/browse/MOB-11441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ