### PR TITLE
[MOB-11716] Add build steps to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,8 @@ jobs:
           cache: 'yarn'
       - run: yarn install --frozen-lockfile
       - run: yarn test
+      - run: yarn build
+      - run: yarn build:node
       - uses: JS-DevTools/npm-publish@19c28f1ef146469e409470805ea4279d47c3d35c # v3.1.1
         with:
           token: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## JIRA Ticket(s) if any

* [MOB-11716](https://iterable.atlassian.net/browse/MOB-11716)

## Description

* This should fix the issue with the build artifacts not being generated prior to publish.

## Test Steps