### PR TITLE
[MOB-11679]: consent loggimg implementation

### DIFF
--- a/react-example/src/index.tsx
+++ b/react-example/src/index.tsx
@@ -47,7 +47,11 @@ const HomeLink = styled(Link)`
     configOptions: {
       isEuIterableService: false,
       dangerouslyAllowJsPopups: true,
-      enableUnknownActivation: true
+      enableUnknownActivation: true,
+      identityResolution: {
+        replayOnVisitorToKnown: true,
+        mergeOnUnknownToKnown: true
+      }
     },
     generateJWT: ({ email, userID }) =>
       axios

--- a/src/authorization/authorization.ts
+++ b/src/authorization/authorization.ts
@@ -11,7 +11,6 @@ import {
   SHARED_PREF_UNKNOWN_USAGE_TRACKED,
   SHARED_PREFS_CRITERIA,
   SHARED_PREF_CONSENT_TIMESTAMP,
-  SHARED_PREF_CONSENT_SENT,
   SHARED_PREF_EMAIL,
   SHARED_PREF_USER_ID
 } from 'src/constants';
@@ -579,7 +578,6 @@ export function initialize(
             localStorage.removeItem(SHARED_PREF_UNKNOWN_USER_ID);
             localStorage.removeItem(SHARED_PREF_UNKNOWN_USAGE_TRACKED);
             localStorage.removeItem(SHARED_PREF_CONSENT_TIMESTAMP);
-            localStorage.removeItem(SHARED_PREF_CONSENT_SENT);
 
             setTypeOfAuth(null);
             authIdentifier = null;
@@ -1016,7 +1014,6 @@ export function initialize(
           localStorage.removeItem(SHARED_PREF_UNKNOWN_USER_ID);
           localStorage.removeItem(SHARED_PREF_UNKNOWN_USAGE_TRACKED);
           localStorage.removeItem(SHARED_PREF_CONSENT_TIMESTAMP);
-          localStorage.removeItem(SHARED_PREF_CONSENT_SENT);
 
           setTypeOfAuth(null);
           authIdentifier = null;

--- a/src/authorization/authorization.ts
+++ b/src/authorization/authorization.ts
@@ -9,7 +9,11 @@ import {
   ENDPOINTS,
   RouteConfig,
   SHARED_PREF_UNKNOWN_USAGE_TRACKED,
-  SHARED_PREFS_CRITERIA
+  SHARED_PREFS_CRITERIA,
+  SHARED_PREF_CONSENT_TIMESTAMP,
+  SHARED_PREF_CONSENT_SENT,
+  SHARED_PREF_EMAIL,
+  SHARED_PREF_USER_ID
 } from 'src/constants';
 import {
   cancelAxiosRequestAndMakeFetch,
@@ -116,6 +120,7 @@ const initializeUserId = (userId: string) => {
 const addUserIdToRequest = (userId: string) => {
   setTypeOfAuth('userID');
   authIdentifier = userId;
+  localStorage.setItem(SHARED_PREF_USER_ID, userId);
 
   if (typeof userInterceptor === 'number') {
     baseAxiosRequest.interceptors.request.eject(userInterceptor);
@@ -213,15 +218,16 @@ const initializeEmailUser = (email: string) => {
   clearUnknownUser();
 };
 
-const syncEvents = () => {
+const syncEvents = (isUserKnown?: boolean) => {
   if (config.getConfig('enableUnknownActivation')) {
-    unknownUserManager.syncEvents();
+    unknownUserManager.syncEvents(isUserKnown);
   }
 };
 
 const addEmailToRequest = (email: string) => {
   setTypeOfAuth('email');
   authIdentifier = email;
+  localStorage.setItem(SHARED_PREF_EMAIL, email);
 
   if (typeof userInterceptor === 'number') {
     baseAxiosRequest.interceptors.request.eject(userInterceptor);
@@ -487,7 +493,7 @@ export function initialize(
           if (result) {
             initializeEmailUser(email);
             if (replay) {
-              syncEvents();
+              syncEvents(true);
             } else {
               unknownUserManager.removeUnknownSessionCriteriaData();
             }
@@ -517,7 +523,7 @@ export function initialize(
           if (result) {
             initializeUserId(userId);
             if (replay) {
-              syncEvents();
+              syncEvents(true);
             } else {
               unknownUserManager.removeUnknownSessionCriteriaData();
             }
@@ -532,6 +538,8 @@ export function initialize(
         unknownUserManager.removeUnknownSessionCriteriaData();
         setTypeOfAuth(null);
         authIdentifier = null;
+        localStorage.removeItem(SHARED_PREF_EMAIL);
+        localStorage.removeItem(SHARED_PREF_USER_ID);
         /* clear fetched in-app messages */
         clearMessages();
 
@@ -555,6 +563,11 @@ export function initialize(
           localStorage.removeItem(SHARED_PREFS_CRITERIA);
 
           localStorage.setItem(SHARED_PREF_UNKNOWN_USAGE_TRACKED, 'true');
+          // Store consent timestamp when user grants consent
+          const existingConsent = localStorage.getItem(SHARED_PREF_CONSENT_TIMESTAMP);
+          if (!existingConsent) {
+            localStorage.setItem(SHARED_PREF_CONSENT_TIMESTAMP, Date.now().toString());
+          }
           enableUnknownTracking();
         } else {
           /* if consent is false, we want to stop tracking and clear unknown user data */
@@ -565,6 +578,8 @@ export function initialize(
             localStorage.removeItem(SHARED_PREFS_CRITERIA);
             localStorage.removeItem(SHARED_PREF_UNKNOWN_USER_ID);
             localStorage.removeItem(SHARED_PREF_UNKNOWN_USAGE_TRACKED);
+            localStorage.removeItem(SHARED_PREF_CONSENT_TIMESTAMP);
+            localStorage.removeItem(SHARED_PREF_CONSENT_SENT);
 
             setTypeOfAuth(null);
             authIdentifier = null;
@@ -873,7 +888,7 @@ export function initialize(
               if (result) {
                 initializeEmailUser(email);
                 if (replay) {
-                  syncEvents();
+                  syncEvents(true);
                 } else {
                   unknownUserManager.removeUnknownSessionCriteriaData();
                 }
@@ -918,7 +933,7 @@ export function initialize(
               if (result) {
                 initializeUserId(userId);
                 if (replay) {
-                  syncEvents();
+                  syncEvents(true);
                 } else {
                   unknownUserManager.removeUnknownSessionCriteriaData();
                 }
@@ -946,6 +961,8 @@ export function initialize(
       unknownUserManager.removeUnknownSessionCriteriaData();
       setTypeOfAuth(null);
       authIdentifier = null;
+      localStorage.removeItem(SHARED_PREF_EMAIL);
+      localStorage.removeItem(SHARED_PREF_USER_ID);
       /* clear fetched in-app messages */
       clearMessages();
 
@@ -983,6 +1000,11 @@ export function initialize(
         localStorage.removeItem(SHARED_PREFS_CRITERIA);
 
         localStorage.setItem(SHARED_PREF_UNKNOWN_USAGE_TRACKED, 'true');
+        // Store consent timestamp when user grants consent
+        const existingConsent = localStorage.getItem(SHARED_PREF_CONSENT_TIMESTAMP);
+        if (!existingConsent) {
+          localStorage.setItem(SHARED_PREF_CONSENT_TIMESTAMP, Date.now().toString());
+        }
         enableUnknownTracking();
       } else {
         /* if consent is false, we want to stop tracking and clear unknown user data */
@@ -993,6 +1015,8 @@ export function initialize(
           localStorage.removeItem(SHARED_PREFS_CRITERIA);
           localStorage.removeItem(SHARED_PREF_UNKNOWN_USER_ID);
           localStorage.removeItem(SHARED_PREF_UNKNOWN_USAGE_TRACKED);
+          localStorage.removeItem(SHARED_PREF_CONSENT_TIMESTAMP);
+          localStorage.removeItem(SHARED_PREF_CONSENT_SENT);
 
           setTypeOfAuth(null);
           authIdentifier = null;

--- a/src/authorization/consentStorage.test.ts
+++ b/src/authorization/consentStorage.test.ts
@@ -1,0 +1,193 @@
+import {
+  SHARED_PREF_CONSENT_TIMESTAMP,
+  SHARED_PREF_UNKNOWN_USAGE_TRACKED,
+  SHARED_PREFS_CRITERIA,
+  SHARED_PREF_UNKNOWN_USER_ID
+} from '../constants';
+
+const localStorageMock = {
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn()
+};
+
+// Mock the modules
+jest.mock('../inapp/inapp', () => ({
+  clearMessages: jest.fn()
+}));
+
+jest.mock('../unknownUserTracking/unknownUserEventManager', () => ({
+  UnknownUserEventManager: jest.fn().mockImplementation(() => ({
+    removeUnknownSessionCriteriaData: jest.fn(),
+    getUnknownCriteria: jest.fn(),
+    updateUnknownSession: jest.fn()
+  })),
+  isUnknownUsageTracked: jest.fn().mockReturnValue(true),
+  registerUnknownUserIdSetter: jest.fn()
+}));
+
+jest.mock('../utils/config', () => ({
+  __esModule: true,
+  default: {
+    getConfig: jest.fn().mockReturnValue(true)
+  }
+}));
+
+jest.mock('../utils/typeOfAuth', () => ({
+  setTypeOfAuth: jest.fn(),
+  getTypeOfAuth: jest.fn()
+}));
+
+jest.mock('../unknownUserTracking/unknownUserMerge', () => ({
+  UnknownUserMerge: jest.fn()
+}));
+
+jest.mock('../utils/authorizationToken', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => ({
+    setToken: jest.fn(),
+    getToken: jest.fn(),
+    clearToken: jest.fn()
+  }))
+}));
+
+jest.mock('../request', () => ({
+  baseAxiosRequest: {
+    interceptors: {
+      request: {
+        use: jest.fn(),
+        eject: jest.fn()
+      }
+    }
+  }
+}));
+
+describe('Consent Storage in Authorization', () => {
+  beforeEach(() => {
+    (global as any).localStorage = localStorageMock;
+    (global as any).window = {
+      location: { hostname: 'test.example.com' }
+    };
+    (global as any).navigator = { userAgent: 'test-user-agent' };
+
+    jest.clearAllMocks();
+    // Reset Date.now to a known value
+    jest.spyOn(Date, 'now').mockReturnValue(1234567890);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('setVisitorUsageTracked', () => {
+    let setVisitorUsageTracked: (consent: boolean) => void;
+
+    beforeEach(async () => {
+      // Import and initialize after mocks are set up
+      const { initialize } = await import('.');
+      const auth = initialize('test-api-key');
+      setVisitorUsageTracked = auth.setVisitorUsageTracked;
+    });
+
+    it('should store consent timestamp when consent is granted for the first time', () => {
+      localStorageMock.getItem.mockReturnValue(null); // No existing consent
+
+      setVisitorUsageTracked(true);
+
+      expect(localStorageMock.setItem).toHaveBeenCalledWith(
+        SHARED_PREF_CONSENT_TIMESTAMP,
+        '1234567890'
+      );
+      expect(localStorageMock.setItem).toHaveBeenCalledWith(
+        SHARED_PREF_UNKNOWN_USAGE_TRACKED,
+        'true'
+      );
+    });
+
+    it('should not overwrite existing consent timestamp when consent is granted again', () => {
+      localStorageMock.getItem.mockImplementation((key) => {
+        if (key === SHARED_PREF_CONSENT_TIMESTAMP) return '9876543210'; // Existing timestamp
+        return null;
+      });
+
+      setVisitorUsageTracked(true);
+
+      expect(localStorageMock.setItem).not.toHaveBeenCalledWith(
+        SHARED_PREF_CONSENT_TIMESTAMP,
+        expect.any(String)
+      );
+      expect(localStorageMock.setItem).toHaveBeenCalledWith(
+        SHARED_PREF_UNKNOWN_USAGE_TRACKED,
+        'true'
+      );
+    });
+
+    it('should remove consent timestamp when consent is revoked', () => {
+      localStorageMock.getItem.mockImplementation((key) => {
+        if (key === SHARED_PREF_UNKNOWN_USAGE_TRACKED) return 'true';
+        return null;
+      });
+
+      setVisitorUsageTracked(false);
+
+      expect(localStorageMock.removeItem).toHaveBeenCalledWith(
+        SHARED_PREF_CONSENT_TIMESTAMP
+      );
+      expect(localStorageMock.removeItem).toHaveBeenCalledWith(
+        SHARED_PREFS_CRITERIA
+      );
+      expect(localStorageMock.removeItem).toHaveBeenCalledWith(
+        SHARED_PREF_UNKNOWN_USER_ID
+      );
+      expect(localStorageMock.removeItem).toHaveBeenCalledWith(
+        SHARED_PREF_UNKNOWN_USAGE_TRACKED
+      );
+    });
+
+    it('should set unknown usage tracked to false when consent is revoked', () => {
+      setVisitorUsageTracked(false);
+
+      expect(localStorageMock.setItem).toHaveBeenCalledWith(
+        SHARED_PREF_UNKNOWN_USAGE_TRACKED,
+        'false'
+      );
+    });
+  });
+
+  describe('setVisitorUsageTracked with JWT', () => {
+    let setVisitorUsageTracked: (consent: boolean) => void;
+
+    beforeEach(async () => {
+      // Mock JWT function
+      const mockGenerateJWT = jest.fn().mockResolvedValue('mock-jwt-token');
+
+      const { initialize } = await import('.');
+      const auth = initialize('test-api-key', mockGenerateJWT);
+      setVisitorUsageTracked = auth.setVisitorUsageTracked;
+    });
+
+    it('should store consent timestamp when consent is granted (JWT mode)', () => {
+      localStorageMock.getItem.mockReturnValue(null); // No existing consent
+
+      setVisitorUsageTracked(true);
+
+      expect(localStorageMock.setItem).toHaveBeenCalledWith(
+        SHARED_PREF_CONSENT_TIMESTAMP,
+        '1234567890'
+      );
+    });
+
+    it('should remove consent timestamp when consent is revoked (JWT mode)', () => {
+      localStorageMock.getItem.mockImplementation((key) => {
+        if (key === SHARED_PREF_UNKNOWN_USAGE_TRACKED) return 'true';
+        return null;
+      });
+
+      setVisitorUsageTracked(false);
+
+      expect(localStorageMock.removeItem).toHaveBeenCalledWith(
+        SHARED_PREF_CONSENT_TIMESTAMP
+      );
+    });
+  });
+});

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -289,7 +289,6 @@ export const SHARED_PREFS_UNKNOWN_SESSIONS = 'itbl_unknown_sessions';
 export const SHARED_PREF_UNKNOWN_USER_ID = 'unknown_userId';
 export const SHARED_PREF_UNKNOWN_USAGE_TRACKED = 'itbl_unknown_usage_tracked';
 export const SHARED_PREF_CONSENT_TIMESTAMP = 'itbl_consent_timestamp';
-export const SHARED_PREF_CONSENT_SENT = 'itbl_consent_sent';
 export const SHARED_PREF_USER_TOKEN = 'itbl_auth_token';
 
 export const KEY_EVENT_NAME = 'eventName';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -29,6 +29,7 @@ export const GETMESSAGES_PATH = '/inApp/web/getMessages';
 export const GET_CRITERIA_PATH = '/unknownuser/list';
 export const ENDPOINT_MERGE_USER = '/users/merge';
 export const ENDPOINT_TRACK_UNKNOWN_SESSION = '/unknownuser/events/session';
+export const ENDPOINT_UNKNOWN_USER_CONSENT = '/unknownuser/consent';
 
 const GET_ENABLE_INAPP_CONSUME = () => {
   try {
@@ -287,6 +288,8 @@ export const SHARED_PREFS_CRITERIA = 'criteria';
 export const SHARED_PREFS_UNKNOWN_SESSIONS = 'itbl_unknown_sessions';
 export const SHARED_PREF_UNKNOWN_USER_ID = 'unknown_userId';
 export const SHARED_PREF_UNKNOWN_USAGE_TRACKED = 'itbl_unknown_usage_tracked';
+export const SHARED_PREF_CONSENT_TIMESTAMP = 'itbl_consent_timestamp';
+export const SHARED_PREF_CONSENT_SENT = 'itbl_consent_sent';
 export const SHARED_PREF_USER_TOKEN = 'itbl_auth_token';
 
 export const KEY_EVENT_NAME = 'eventName';

--- a/src/request.ts
+++ b/src/request.ts
@@ -7,7 +7,8 @@ import {
   EU_ITERABLE_API,
   GET_CRITERIA_PATH,
   INITIALIZE_ERROR,
-  ENDPOINT_TRACK_UNKNOWN_SESSION
+  ENDPOINT_TRACK_UNKNOWN_SESSION,
+  ENDPOINT_UNKNOWN_USER_CONSENT
 } from './constants';
 import { IterablePromise, IterableResponse } from './types';
 import { config } from './utils/config';
@@ -31,7 +32,8 @@ interface ClientError extends IterableResponse {
 
 const ENDPOINTS_NOT_REQUIRING_TYPE_OF_AUTH = [
   GET_CRITERIA_PATH,
-  ENDPOINT_TRACK_UNKNOWN_SESSION
+  ENDPOINT_TRACK_UNKNOWN_SESSION,
+  ENDPOINT_UNKNOWN_USER_CONSENT
 ];
 
 export const baseAxiosRequest = Axios.create({

--- a/src/unknownUserTracking/consent.schema.ts
+++ b/src/unknownUserTracking/consent.schema.ts
@@ -1,0 +1,15 @@
+import { boolean, number, object, string } from 'yup';
+
+export const consentRequestSchema = object().shape({
+  consentTimestamp: number().required(),
+  email: string(),
+  userId: string(),
+  isUserKnown: boolean().required(),
+  deviceInfo: object()
+    .shape({
+      deviceId: string().required(),
+      platform: string().required(),
+      appPackageName: string().required()
+    })
+    .required()
+});

--- a/src/unknownUserTracking/tests/consentTracking.test.ts
+++ b/src/unknownUserTracking/tests/consentTracking.test.ts
@@ -1,0 +1,525 @@
+import { UnknownUserEventManager } from '../unknownUserEventManager';
+import { baseIterableRequest } from '../../request';
+import {
+  SHARED_PREF_CONSENT_TIMESTAMP,
+  SHARED_PREF_EMAIL,
+  SHARED_PREF_USER_ID,
+  SHARED_PREF_UNKNOWN_USER_ID,
+  SHARED_PREF_CONSENT_SENT,
+  ENDPOINT_UNKNOWN_USER_CONSENT,
+  WEB_PLATFORM
+} from '../../constants';
+import { getTypeOfAuth } from '../../utils/typeOfAuth';
+import config from '../../utils/config';
+
+const localStorageMock = {
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn()
+};
+
+jest.mock('../../request', () => ({
+  baseIterableRequest: jest.fn()
+}));
+
+jest.mock('../../utils/typeOfAuth', () => ({
+  getTypeOfAuth: jest.fn(),
+  setTypeOfAuth: jest.fn()
+}));
+
+jest.mock('../../utils/config', () => ({
+  __esModule: true,
+  default: {
+    getConfig: jest.fn()
+  }
+}));
+
+describe('Consent Tracking', () => {
+  let unknownUserEventManager: UnknownUserEventManager;
+  const mockBaseIterableRequest = baseIterableRequest as jest.MockedFunction<
+    typeof baseIterableRequest
+  >;
+  const mockGetTypeOfAuth = getTypeOfAuth as jest.MockedFunction<
+    typeof getTypeOfAuth
+  >;
+  const mockConfig = config as jest.Mocked<typeof config>;
+
+  beforeEach(() => {
+    (global as any).localStorage = localStorageMock;
+
+    // Mock window and navigator
+    (global as any).window = {
+      location: { hostname: 'test.example.com' },
+      navigator: { userAgent: 'test-user-agent' }
+    };
+    (global as any).navigator = { userAgent: 'test-user-agent' };
+
+    unknownUserEventManager = new UnknownUserEventManager();
+    jest.clearAllMocks();
+
+    // Default mocks
+    mockGetTypeOfAuth.mockReturnValue(null);
+    mockConfig.getConfig.mockReturnValue({
+      replayOnVisitorToKnown: true,
+      mergeOnUnknownToKnown: true
+    });
+  });
+
+  describe('getConsentTimestamp', () => {
+    it('should return consent timestamp from localStorage', () => {
+      const timestamp = '1234567890';
+      localStorageMock.getItem.mockReturnValue(timestamp);
+
+      const result = unknownUserEventManager.getConsentTimestamp();
+
+      expect(localStorageMock.getItem).toHaveBeenCalledWith(
+        SHARED_PREF_CONSENT_TIMESTAMP
+      );
+      expect(result).toBe(timestamp);
+    });
+
+    it('should return null when no consent timestamp exists', () => {
+      localStorageMock.getItem.mockReturnValue(null);
+
+      const result = unknownUserEventManager.getConsentTimestamp();
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('hasConsent', () => {
+    it('should return true when consent timestamp exists', () => {
+      localStorageMock.getItem.mockReturnValue('1234567890');
+
+      const result = unknownUserEventManager.hasConsent();
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false when no consent timestamp exists', () => {
+      localStorageMock.getItem.mockReturnValue(null);
+
+      const result = unknownUserEventManager.hasConsent();
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('getCurrentUserInfo', () => {
+    it('should return email when auth type is email', () => {
+      mockGetTypeOfAuth.mockReturnValue('email');
+      localStorageMock.getItem.mockImplementation((key) => {
+        if (key === SHARED_PREF_EMAIL) return 'test@example.com';
+        return null;
+      });
+
+      const userInfo = (unknownUserEventManager as any).getCurrentUserInfo();
+
+      expect(userInfo).toEqual({ email: 'test@example.com' });
+    });
+
+    it('should return userId when auth type is userID', () => {
+      mockGetTypeOfAuth.mockReturnValue('userID');
+      localStorageMock.getItem.mockImplementation((key) => {
+        if (key === SHARED_PREF_USER_ID) return 'user123';
+        return null;
+      });
+
+      const userInfo = (unknownUserEventManager as any).getCurrentUserInfo();
+
+      expect(userInfo).toEqual({ userId: 'user123' });
+    });
+
+    it('should return empty object when no auth type', () => {
+      mockGetTypeOfAuth.mockReturnValue(null);
+
+      const userInfo = (unknownUserEventManager as any).getCurrentUserInfo();
+
+      expect(userInfo).toEqual({});
+    });
+
+    it('should return empty object when email not found in localStorage', () => {
+      mockGetTypeOfAuth.mockReturnValue('email');
+      localStorageMock.getItem.mockReturnValue(null);
+
+      const userInfo = (unknownUserEventManager as any).getCurrentUserInfo();
+
+      expect(userInfo).toEqual({});
+    });
+
+    it('should return unknown userId when no auth type but unknown user ID exists', () => {
+      mockGetTypeOfAuth.mockReturnValue(null);
+      localStorageMock.getItem.mockImplementation((key) => {
+        if (key === SHARED_PREF_UNKNOWN_USER_ID) return 'unknown-user-123';
+        return null;
+      });
+
+      const userInfo = (unknownUserEventManager as any).getCurrentUserInfo();
+
+      expect(userInfo).toEqual({ userId: 'unknown-user-123' });
+    });
+
+    it('should prioritize actual email over unknown user ID when both exist', () => {
+      mockGetTypeOfAuth.mockReturnValue('email');
+      localStorageMock.getItem.mockImplementation((key) => {
+        if (key === SHARED_PREF_EMAIL) return 'real-user@example.com';
+        if (key === SHARED_PREF_UNKNOWN_USER_ID) return 'unknown-user-456';
+        return null;
+      });
+
+      const userInfo = (unknownUserEventManager as any).getCurrentUserInfo();
+
+      expect(userInfo).toEqual({ email: 'real-user@example.com' });
+    });
+
+    it('should prioritize actual userId over unknown user ID when both exist', () => {
+      mockGetTypeOfAuth.mockReturnValue('userID');
+      localStorageMock.getItem.mockImplementation((key) => {
+        if (key === SHARED_PREF_USER_ID) return 'real-user-123';
+        if (key === SHARED_PREF_UNKNOWN_USER_ID) return 'unknown-user-456';
+        return null;
+      });
+
+      const userInfo = (unknownUserEventManager as any).getCurrentUserInfo();
+
+      expect(userInfo).toEqual({ userId: 'real-user-123' });
+    });
+  });
+
+  describe('trackConsent', () => {
+    const mockTimestamp = '1234567890';
+
+    beforeEach(() => {
+      localStorageMock.getItem.mockImplementation((key) => {
+        if (key === SHARED_PREF_CONSENT_TIMESTAMP) return mockTimestamp;
+        return null;
+      });
+      mockBaseIterableRequest.mockResolvedValue({
+        data: { success: true },
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: {}
+      } as any);
+    });
+
+    it('should make consent request with correct payload when user is known', async () => {
+      mockGetTypeOfAuth.mockReturnValue('email');
+      localStorageMock.getItem.mockImplementation((key) => {
+        if (key === SHARED_PREF_CONSENT_TIMESTAMP) return mockTimestamp;
+        if (key === SHARED_PREF_EMAIL) return 'test@example.com';
+        return null;
+      });
+
+      await unknownUserEventManager.trackConsent(true);
+
+      expect(mockBaseIterableRequest).toHaveBeenCalledWith({
+        method: 'POST',
+        url: ENDPOINT_UNKNOWN_USER_CONSENT,
+        data: {
+          consentTimestamp: parseInt(mockTimestamp, 10),
+          isUserKnown: true,
+          email: 'test@example.com',
+          deviceInfo: {
+            appPackageName: window.location.hostname,
+            deviceId: global.navigator.userAgent || '',
+            platform: WEB_PLATFORM
+          }
+        },
+        validation: {
+          data: expect.any(Object)
+        }
+      });
+    });
+
+    it('should make consent request with userId when user is authenticated with userID', async () => {
+      mockGetTypeOfAuth.mockReturnValue('userID');
+      localStorageMock.getItem.mockImplementation((key) => {
+        if (key === SHARED_PREF_CONSENT_TIMESTAMP) return mockTimestamp;
+        if (key === SHARED_PREF_USER_ID) return 'user123';
+        return null;
+      });
+
+      await unknownUserEventManager.trackConsent(false);
+
+      expect(mockBaseIterableRequest).toHaveBeenCalledWith({
+        method: 'POST',
+        url: ENDPOINT_UNKNOWN_USER_CONSENT,
+        data: {
+          consentTimestamp: parseInt(mockTimestamp, 10),
+          isUserKnown: false,
+          userId: 'user123',
+          deviceInfo: {
+            appPackageName: window.location.hostname,
+            deviceId: global.navigator.userAgent || '',
+            platform: WEB_PLATFORM
+          }
+        },
+        validation: {
+          data: expect.any(Object)
+        }
+      });
+    });
+
+    it('should make consent request without user info when not authenticated', async () => {
+      mockGetTypeOfAuth.mockReturnValue(null);
+
+      await unknownUserEventManager.trackConsent(false);
+
+      expect(mockBaseIterableRequest).toHaveBeenCalledWith({
+        method: 'POST',
+        url: ENDPOINT_UNKNOWN_USER_CONSENT,
+        data: {
+          consentTimestamp: parseInt(mockTimestamp, 10),
+          isUserKnown: false,
+          deviceInfo: {
+            appPackageName: window.location.hostname,
+            deviceId: global.navigator.userAgent || '',
+            platform: WEB_PLATFORM
+          }
+        },
+        validation: {
+          data: expect.any(Object)
+        }
+      });
+    });
+
+    it('should return null when no consent timestamp exists', async () => {
+      localStorageMock.getItem.mockImplementation((key) => {
+        if (key === SHARED_PREF_CONSENT_TIMESTAMP) return null;
+        return null;
+      });
+
+      const result = await unknownUserEventManager.trackConsent(true);
+
+      expect(result).toBeNull();
+      expect(mockBaseIterableRequest).not.toHaveBeenCalled();
+    });
+
+    it('should make consent request with unknown userId when no auth type but unknown user ID exists', async () => {
+      mockGetTypeOfAuth.mockReturnValue(null);
+      localStorageMock.getItem.mockImplementation((key) => {
+        if (key === SHARED_PREF_CONSENT_TIMESTAMP) return mockTimestamp;
+        if (key === SHARED_PREF_UNKNOWN_USER_ID) return 'unknown-user-456';
+        return null;
+      });
+
+      await unknownUserEventManager.trackConsent(false);
+
+      expect(mockBaseIterableRequest).toHaveBeenCalledWith({
+        method: 'POST',
+        url: ENDPOINT_UNKNOWN_USER_CONSENT,
+        data: {
+          consentTimestamp: parseInt(mockTimestamp, 10),
+          isUserKnown: false,
+          userId: 'unknown-user-456',
+          deviceInfo: {
+            appPackageName: window.location.hostname,
+            deviceId: global.navigator.userAgent || '',
+            platform: WEB_PLATFORM
+          }
+        },
+        validation: {
+          data: expect.any(Object)
+        }
+      });
+    });
+
+    it('should handle request errors gracefully', async () => {
+      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+      mockBaseIterableRequest.mockRejectedValue(new Error('Network error'));
+
+      const result = await unknownUserEventManager.trackConsent(true);
+
+      expect(result).toBeNull();
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        'Failed to track consent:',
+        expect.any(Error)
+      );
+      consoleWarnSpy.mockRestore();
+    });
+
+    it('should not track consent if already sent (prevents duplicate calls)', async () => {
+      mockGetTypeOfAuth.mockReturnValue('email');
+      localStorageMock.getItem.mockImplementation((key) => {
+        if (key === SHARED_PREF_CONSENT_TIMESTAMP) return mockTimestamp;
+        if (key === SHARED_PREF_EMAIL) return 'test@example.com';
+        if (key === SHARED_PREF_CONSENT_SENT) return 'true'; // Already sent
+        return null;
+      });
+
+      const result = await unknownUserEventManager.trackConsent(true);
+
+      // Should return null without making a request
+      expect(result).toBeNull();
+      expect(mockBaseIterableRequest).not.toHaveBeenCalled();
+    });
+
+    it('should mark consent as sent after successful request', async () => {
+      mockGetTypeOfAuth.mockReturnValue('email');
+      localStorageMock.getItem.mockImplementation((key) => {
+        if (key === SHARED_PREF_CONSENT_TIMESTAMP) return mockTimestamp;
+        if (key === SHARED_PREF_EMAIL) return 'test@example.com';
+        if (key === SHARED_PREF_CONSENT_SENT) return null; // Not sent yet
+        return null;
+      });
+
+      await unknownUserEventManager.trackConsent(true);
+
+      expect(mockBaseIterableRequest).toHaveBeenCalled();
+      expect(localStorageMock.setItem).toHaveBeenCalledWith(
+        SHARED_PREF_CONSENT_SENT,
+        'true'
+      );
+    });
+
+    it('should not mark consent as sent if request fails', async () => {
+      mockGetTypeOfAuth.mockReturnValue('email');
+      localStorageMock.getItem.mockImplementation((key) => {
+        if (key === SHARED_PREF_CONSENT_TIMESTAMP) return mockTimestamp;
+        if (key === SHARED_PREF_EMAIL) return 'test@example.com';
+        if (key === SHARED_PREF_CONSENT_SENT) return null; // Not sent yet
+        return null;
+      });
+
+      // Mock failed request
+      mockBaseIterableRequest.mockRejectedValue(new Error('Network error'));
+      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+      await unknownUserEventManager.trackConsent(true);
+
+      expect(mockBaseIterableRequest).toHaveBeenCalled();
+      expect(localStorageMock.setItem).not.toHaveBeenCalledWith(
+        SHARED_PREF_CONSENT_SENT,
+        'true'
+      );
+
+      consoleWarnSpy.mockRestore();
+    });
+  });
+
+  describe('syncEvents with consent tracking', () => {
+    beforeEach(() => {
+      // Mock empty event lists to focus on consent testing
+      localStorageMock.getItem.mockImplementation((key) => {
+        if (key === 'itbl_event_list') return null;
+        if (key === 'itbl_user_update_object') return null;
+        return null;
+      });
+    });
+
+    it('should track consent when consent exists and replay is enabled', async () => {
+      const timestamp = '1234567890';
+      localStorageMock.getItem.mockImplementation((key) => {
+        if (key === SHARED_PREF_CONSENT_TIMESTAMP) return timestamp;
+        return null;
+      });
+      mockConfig.getConfig.mockReturnValue({
+        replayOnVisitorToKnown: true
+      });
+      mockBaseIterableRequest.mockResolvedValue({
+        data: { success: true },
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: {}
+      } as any);
+
+      const trackConsentSpy = jest.spyOn(
+        unknownUserEventManager,
+        'trackConsent'
+      );
+
+      await unknownUserEventManager.syncEvents(true);
+
+      expect(trackConsentSpy).toHaveBeenCalledWith(true);
+    });
+
+    it('should not track consent when replay is disabled', async () => {
+      const timestamp = '1234567890';
+      localStorageMock.getItem.mockImplementation((key) => {
+        if (key === SHARED_PREF_CONSENT_TIMESTAMP) return timestamp;
+        return null;
+      });
+      mockConfig.getConfig.mockReturnValue({
+        replayOnVisitorToKnown: false
+      });
+
+      const trackConsentSpy = jest.spyOn(
+        unknownUserEventManager,
+        'trackConsent'
+      );
+
+      await unknownUserEventManager.syncEvents(true);
+
+      expect(trackConsentSpy).not.toHaveBeenCalled();
+    });
+
+    it('should not track consent when no consent timestamp exists', async () => {
+      localStorageMock.getItem.mockImplementation((key) => {
+        if (key === SHARED_PREF_CONSENT_TIMESTAMP) return null;
+        return null;
+      });
+      mockConfig.getConfig.mockReturnValue({
+        replayOnVisitorToKnown: true
+      });
+
+      const trackConsentSpy = jest.spyOn(
+        unknownUserEventManager,
+        'trackConsent'
+      );
+
+      await unknownUserEventManager.syncEvents(true);
+
+      expect(trackConsentSpy).not.toHaveBeenCalled();
+    });
+
+    it('should continue with event replay if consent tracking fails', async () => {
+      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+      const timestamp = '1234567890';
+      localStorageMock.getItem.mockImplementation((key) => {
+        if (key === SHARED_PREF_CONSENT_TIMESTAMP) return timestamp;
+        return null;
+      });
+      mockConfig.getConfig.mockReturnValue({
+        replayOnVisitorToKnown: true
+      });
+
+      // Mock trackConsent to throw an error
+      jest
+        .spyOn(unknownUserEventManager, 'trackConsent')
+        .mockRejectedValue(new Error('Consent failed'));
+
+      // Should not throw an error
+      await expect(
+        unknownUserEventManager.syncEvents(true)
+      ).resolves.toBeUndefined();
+
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        'Consent tracking failed, continuing with event replay:',
+        expect.any(Error)
+      );
+
+      consoleWarnSpy.mockRestore();
+    });
+
+    it('should pass isUserKnown as false by default', async () => {
+      const timestamp = '1234567890';
+      localStorageMock.getItem.mockImplementation((key) => {
+        if (key === SHARED_PREF_CONSENT_TIMESTAMP) return timestamp;
+        return null;
+      });
+      mockConfig.getConfig.mockReturnValue({
+        replayOnVisitorToKnown: true
+      });
+
+      const trackConsentSpy = jest
+        .spyOn(unknownUserEventManager, 'trackConsent')
+        .mockResolvedValue(null);
+
+      await unknownUserEventManager.syncEvents();
+
+      expect(trackConsentSpy).toHaveBeenCalledWith(false);
+    });
+  });
+});

--- a/src/unknownUserTracking/tests/unknownUserEventManager.test.ts
+++ b/src/unknownUserTracking/tests/unknownUserEventManager.test.ts
@@ -4,7 +4,9 @@ import {
   SHARED_PREFS_UNKNOWN_SESSIONS,
   SHARED_PREFS_EVENT_LIST_KEY,
   SHARED_PREFS_CRITERIA,
-  SHARED_PREF_UNKNOWN_USAGE_TRACKED
+  SHARED_PREF_UNKNOWN_USAGE_TRACKED,
+  ENDPOINT_TRACK_UNKNOWN_SESSION,
+  SHARED_PREFS_USER_UPDATE_OBJECT_KEY
 } from '../../constants';
 import { UpdateUserParams } from '../../users';
 import { TrackPurchaseRequestParams } from '../../commerce';
@@ -515,5 +517,87 @@ describe('UnknownUserEventManager', () => {
       return null;
     });
     await unknownUserEventManager.trackUnknownUpdateCart(payload);
+  });
+
+  it('should create session data and call /session immediately when criteria is met without existing session data', async () => {
+    // Mock window object for the test
+    global.window = Object.create({
+      location: { hostname: 'test.example.com' },
+      navigator: { userAgent: 'test-user-agent' }
+    });
+
+    const mockBaseIterableRequest = baseIterableRequest as jest.MockedFunction<
+      typeof baseIterableRequest
+    >;
+
+    // Mock successful session creation response
+    mockBaseIterableRequest.mockResolvedValue({
+      status: 200,
+      data: { success: true }
+    } as any);
+
+    // Create a new instance to test directly
+    const manager = new UnknownUserEventManager();
+
+    // Set up localStorage mocks
+    (localStorage.getItem as jest.Mock).mockImplementation((key) => {
+      if (key === SHARED_PREF_UNKNOWN_USAGE_TRACKED) {
+        return 'true';
+      }
+      // Initially no session data exists
+      if (key === SHARED_PREFS_UNKNOWN_SESSIONS) {
+        return null;
+      }
+      if (key === SHARED_PREFS_USER_UPDATE_OBJECT_KEY) {
+        return null;
+      }
+      return null;
+    });
+
+    // Mock setItem to simulate session creation
+    let sessionDataCreated = false;
+    (localStorage.setItem as jest.Mock).mockImplementation((key) => {
+      if (key === SHARED_PREFS_UNKNOWN_SESSIONS) {
+        sessionDataCreated = true;
+        // After updateUnknownSession is called, simulate the session data being available
+        (localStorage.getItem as jest.Mock).mockImplementation((getKey) => {
+          if (getKey === SHARED_PREFS_UNKNOWN_SESSIONS) {
+            return JSON.stringify({
+              itbl_unknown_sessions: {
+                number_of_sessions: 1,
+                first_session: Math.floor(Date.now() / 1000),
+                last_session: Math.floor(Date.now() / 1000)
+              }
+            });
+          }
+          if (getKey === SHARED_PREF_UNKNOWN_USAGE_TRACKED) {
+            return 'true';
+          }
+          return null;
+        });
+      }
+    });
+
+    // Directly call createUnknownUser with a criteria ID to test the fix
+    await (manager as any).createUnknownUser('123');
+
+    // Verify that session data was created
+    expect(sessionDataCreated).toBe(true);
+
+    // Verify that the session endpoint was called
+    expect(mockBaseIterableRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'POST',
+        url: ENDPOINT_TRACK_UNKNOWN_SESSION,
+        data: expect.objectContaining({
+          user: expect.objectContaining({
+            userId: expect.any(String)
+          }),
+          anonSessionContext: expect.objectContaining({
+            matchedCriteriaId: 123
+          })
+        })
+      })
+    );
   });
 });

--- a/src/unknownUserTracking/unknownUserEventManager.ts
+++ b/src/unknownUserTracking/unknownUserEventManager.ts
@@ -23,17 +23,27 @@ import {
   SHARED_PREFS_CRITERIA,
   SHARED_PREFS_UNKNOWN_SESSIONS,
   ENDPOINT_TRACK_UNKNOWN_SESSION,
+  ENDPOINT_UNKNOWN_USER_CONSENT,
   WEB_PLATFORM,
   KEY_PREFER_USERID,
   ENDPOINTS,
   DEFAULT_EVENT_THRESHOLD_LIMIT,
   SHARED_PREF_UNKNOWN_USAGE_TRACKED,
-  SHARED_PREFS_USER_UPDATE_OBJECT_KEY
+  SHARED_PREF_CONSENT_TIMESTAMP,
+  SHARED_PREF_CONSENT_SENT,
+  SHARED_PREFS_USER_UPDATE_OBJECT_KEY,
+  SHARED_PREF_UNKNOWN_USER_ID,
+  SHARED_PREF_EMAIL,
+  SHARED_PREF_USER_ID
 } from '../constants';
 import { baseIterableRequest } from '../request';
+import { getTypeOfAuth } from '../utils/typeOfAuth';
 import { IterableResponse } from '../types';
 import CriteriaCompletionChecker from './criteriaCompletionChecker';
-import { TrackUnknownSessionParams } from '../utils/types';
+import {
+  TrackUnknownSessionParams,
+  ConsentRequestParams
+} from '../utils/types';
 import { UpdateUserParams } from '../users/types';
 import { trackSchema } from '../events/events.schema';
 import {
@@ -43,6 +53,8 @@ import {
 import { updateUserSchema } from '../users/users.schema';
 import { InAppTrackRequestParams } from '../events';
 import config from '../utils/config';
+
+import { consentRequestSchema } from './consent.schema';
 
 // Type definitions for unknown event data objects
 type UnknownTrackEventData = {
@@ -206,7 +218,7 @@ export class UnknownUserEventManager {
     this.storeEventListToLocalStorage(newDataObject);
   }
 
-  private checkCriteriaCompletion(): string | null {
+  public checkCriteriaCompletion(): string | null {
     const criteriaData = localStorage.getItem(SHARED_PREFS_CRITERIA);
     const localStoredEventList = localStorage.getItem(
       SHARED_PREFS_EVENT_LIST_KEY
@@ -215,9 +227,9 @@ export class UnknownUserEventManager {
       SHARED_PREFS_USER_UPDATE_OBJECT_KEY
     );
     try {
-      if (criteriaData && localStoredEventList) {
+      if (criteriaData && (localStoredEventList || localStoredUserUpdate)) {
         const checker = new CriteriaCompletionChecker(
-          localStoredEventList,
+          localStoredEventList || '',
           localStoredUserUpdate
         );
         return checker.getMatchedCriteria(criteriaData);
@@ -229,12 +241,19 @@ export class UnknownUserEventManager {
     return null;
   }
 
-  private async createUnknownUser(criteriaId: string) {
+  public async createUnknownUser(criteriaId: string) {
     const unknownUsageTracked = isUnknownUsageTracked();
 
     if (!unknownUsageTracked) return;
 
-    const userData = localStorage.getItem(SHARED_PREFS_UNKNOWN_SESSIONS);
+    let userData = localStorage.getItem(SHARED_PREFS_UNKNOWN_SESSIONS);
+
+    // If no session data exists, create it first
+    if (!userData) {
+      this.updateUnknownSession();
+      userData = localStorage.getItem(SHARED_PREFS_UNKNOWN_SESSIONS);
+    }
+
     const strUserUpdate = localStorage.getItem(
       SHARED_PREFS_USER_UPDATE_OBJECT_KEY
     );
@@ -260,12 +279,10 @@ export class UnknownUserEventManager {
           deviceId: global.navigator.userAgent || '',
           platform: WEB_PLATFORM
         },
-        unknownSessionContext: {
-          totalUnknownSessionCount: userDataJson.number_of_sessions || 0,
-          lastUnknownSession:
-            userDataJson.last_session || this.getCurrentTime(),
-          firstUnknownSession:
-            userDataJson.first_session || this.getCurrentTime(),
+        anonSessionContext: {
+          totalAnonSessionCount: userDataJson.number_of_sessions || 0,
+          lastAnonSession: userDataJson.last_session || this.getCurrentTime(),
+          firstAnonSession: userDataJson.first_session || this.getCurrentTime(),
           matchedCriteriaId: parseInt(criteriaId, 10),
           webPushOptIn:
             this.getWebPushOptnIn() !== '' ? this.getWebPushOptnIn() : undefined
@@ -291,12 +308,44 @@ export class UnknownUserEventManager {
         if (unknownUserIdSetter !== null) {
           await unknownUserIdSetter(userId);
         }
-        this.syncEvents();
+        this.syncEvents(false);
       }
     }
   }
 
-  async syncEvents() {
+  async syncEvents(isUserKnown?: boolean) {
+    // Track consent only in specific scenarios:
+    // 1. Unknown user created (isUserKnown: false) - after /session call
+    // 2. User signs up after tracking locally but /session was never called
+    if (this.hasConsent()) {
+      const identityResolutionConfig = config.getConfig('identityResolution');
+      const replayEnabled = identityResolutionConfig?.replayOnVisitorToKnown;
+
+      if (replayEnabled) {
+        try {
+          if (isUserKnown === true) {
+            // Scenario 2: User signed up after tracking locally but /session was never called
+            const unknownUserCreated = localStorage.getItem(
+              SHARED_PREF_UNKNOWN_USER_ID
+            );
+            if (!unknownUserCreated) {
+              await this.trackConsent(true);
+            }
+            // If unknownUserCreated exists, consent was already sent when unknown user was created
+          } else {
+            // Scenario 1: Unknown user created after /session call (false or undefined)
+            await this.trackConsent(false);
+          }
+        } catch (error) {
+          // Don't block event replay if consent tracking fails
+          console.warn(
+            'Consent tracking failed, continuing with event replay:',
+            error
+          );
+        }
+      }
+    }
+
     const strTrackEventList = localStorage.getItem(SHARED_PREFS_EVENT_LIST_KEY);
     const trackEventList = strTrackEventList
       ? JSON.parse(strTrackEventList)
@@ -489,4 +538,85 @@ export class UnknownUserEventManager {
     }
     return null;
   };
+
+  // Consent tracking methods
+  getConsentTimestamp(): string | null {
+    return localStorage.getItem(SHARED_PREF_CONSENT_TIMESTAMP);
+  }
+
+  hasConsent(): boolean {
+    return this.getConsentTimestamp() !== null;
+  }
+
+  private getCurrentUserInfo(): { email?: string; userId?: string } {
+    const typeOfAuth = getTypeOfAuth();
+
+    // First priority: actual user credentials from login/signup
+    if (typeOfAuth === 'email') {
+      const email = localStorage.getItem(SHARED_PREF_EMAIL);
+      if (email) {
+        return { email };
+      }
+    }
+
+    if (typeOfAuth === 'userID') {
+      const userId = localStorage.getItem(SHARED_PREF_USER_ID);
+      if (userId) {
+        return { userId };
+      }
+    }
+
+    // Fallback: generated unknown user ID (for scenario 1: after /session call)
+    const unknownUserId = localStorage.getItem(SHARED_PREF_UNKNOWN_USER_ID);
+    if (unknownUserId) {
+      return { userId: unknownUserId };
+    }
+
+    return {};
+  }
+
+  async trackConsent(isUserKnown: boolean): Promise<any> {
+    const consentTimestamp = this.getConsentTimestamp();
+    if (!consentTimestamp) return null;
+
+    // Check if consent has already been sent to avoid duplicate calls
+    const consentSent = localStorage.getItem(SHARED_PREF_CONSENT_SENT);
+    if (consentSent === 'true') {
+      return null;
+    }
+
+    const userInfo = this.getCurrentUserInfo();
+    const payload: ConsentRequestParams = {
+      consentTimestamp: parseInt(consentTimestamp, 10),
+      isUserKnown,
+      deviceInfo: {
+        appPackageName: window.location.hostname,
+        deviceId: global.navigator.userAgent || '',
+        platform: WEB_PLATFORM
+      },
+      ...userInfo
+    };
+
+    try {
+      const response = await baseIterableRequest<IterableResponse>({
+        method: 'POST',
+        url: ENDPOINT_UNKNOWN_USER_CONSENT,
+        data: payload,
+        validation: {
+          data: consentRequestSchema
+        }
+      });
+
+      // Mark consent as sent only if the request was successful
+      if (response?.status === 200) {
+        localStorage.setItem(SHARED_PREF_CONSENT_SENT, 'true');
+      }
+
+      return response;
+    } catch (error) {
+      // Don't block event replay if consent call fails
+      console.warn('Failed to track consent:', error);
+      return null;
+    }
+  }
 }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,9 +1,9 @@
 import { UpdateUnknownUserParams } from '../users/types';
 
 interface UnknownSessionContext {
-  totalUnknownSessionCount?: number;
-  lastUnknownSession?: number;
-  firstUnknownSession?: number;
+  totalAnonSessionCount?: number;
+  lastAnonSession?: number;
+  firstAnonSession?: number;
   webPushOptIn?: string;
   lastPage?: string;
   matchedCriteriaId: number;
@@ -17,5 +17,17 @@ export interface TrackUnknownSessionParams {
     appPackageName: string; // customer-defined name
     platform: string;
   };
-  unknownSessionContext: UnknownSessionContext;
+  anonSessionContext: UnknownSessionContext;
+}
+
+export interface ConsentRequestParams {
+  consentTimestamp: number;
+  email?: string;
+  userId?: string;
+  isUserKnown: boolean;
+  deviceInfo: {
+    deviceId: string;
+    platform: string;
+    appPackageName: string;
+  };
 }


### PR DESCRIPTION
## JIRA Ticket(s) if any

* [MOB-11679](https://iterable.atlassian.net/browse/MOB-11679)

## Description

Adds consent logging implementation

## Test Steps

Sign up path
1. Without logging in, go to AUT Testing page in react example app
2. Give consent
3. SIgn in to a profile
4. See a successful network call to `/consent`. 

Met Criteria Path
1. Without logging in, go to AUT Testing page in react example app
2. Give consent
3. Meet some criteria from a list
4. See a successful network call to `/consent`.
5. Sign in and see successful merge
6. Check profile in Iterable and see the consent object on profile

Other test cases
- ensure consent doesn't get called when "replay" isn't turned on. 
- ensure UUA still functions the same as before