### PR TITLE
[MOB-11918]: fix user profile updates for UUA

### DIFF
--- a/src/unknownUserTracking/tests/unknownUserEventManager.test.ts
+++ b/src/unknownUserTracking/tests/unknownUserEventManager.test.ts
@@ -636,4 +636,295 @@ describe('UnknownUserEventManager', () => {
       })
     );
   });
+
+  describe('syncEvents', () => {
+    const mockBaseIterableRequest = baseIterableRequest as jest.MockedFunction<
+      typeof baseIterableRequest
+    >;
+
+    beforeEach(() => {
+      mockBaseIterableRequest.mockResolvedValue({
+        status: 200,
+        data: { success: true }
+      } as any);
+    });
+
+    it('should call updateUser with combined dataFields from userUpdateObject', async () => {
+      const userUpdateData = {
+        firstName: 'John',
+        lastName: 'Doe',
+        age: 30,
+        preferences: { theme: 'dark' },
+        eventType: 'userUpdate'
+      };
+
+      (localStorage.getItem as jest.Mock).mockImplementation((key) => {
+        if (key === SHARED_PREFS_USER_UPDATE_OBJECT_KEY) {
+          return JSON.stringify(userUpdateData);
+        }
+        if (key === SHARED_PREFS_EVENT_LIST_KEY) {
+          return JSON.stringify([]);
+        }
+        return null;
+      });
+
+      await unknownUserEventManager.syncEvents();
+
+      expect(mockBaseIterableRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: 'POST',
+          url: expect.stringContaining('/users/update'),
+          data: expect.objectContaining({
+            dataFields: {
+              firstName: 'John',
+              lastName: 'Doe',
+              age: 30,
+              preferences: { theme: 'dark' }
+            },
+            preferUserId: true
+          })
+        })
+      );
+    });
+
+    it('should strip email and userId from dataFields', async () => {
+      const userUpdateData = {
+        email: 'test@example.com',
+        userId: 'user123',
+        firstName: 'John',
+        lastName: 'Doe',
+        eventType: 'userUpdate'
+      };
+
+      (localStorage.getItem as jest.Mock).mockImplementation((key) => {
+        if (key === SHARED_PREFS_USER_UPDATE_OBJECT_KEY) {
+          return JSON.stringify(userUpdateData);
+        }
+        if (key === SHARED_PREFS_EVENT_LIST_KEY) {
+          return JSON.stringify([]);
+        }
+        return null;
+      });
+
+      await unknownUserEventManager.syncEvents();
+
+      expect(mockBaseIterableRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: 'POST',
+          url: expect.stringContaining('/users/update'),
+          data: expect.objectContaining({
+            dataFields: {
+              firstName: 'John',
+              lastName: 'Doe'
+            },
+            preferUserId: true
+          })
+        })
+      );
+
+      // Verify email and userId were stripped
+      const callData = mockBaseIterableRequest.mock.calls[0][0].data;
+      expect(callData.dataFields).not.toHaveProperty('email');
+      expect(callData.dataFields).not.toHaveProperty('userId');
+    });
+
+    it('should not call updateUser when userUpdateObject is empty', async () => {
+      (localStorage.getItem as jest.Mock).mockImplementation((key) => {
+        if (key === SHARED_PREFS_USER_UPDATE_OBJECT_KEY) {
+          return JSON.stringify({});
+        }
+        if (key === SHARED_PREFS_EVENT_LIST_KEY) {
+          return JSON.stringify([]);
+        }
+        return null;
+      });
+
+      await unknownUserEventManager.syncEvents();
+
+      expect(mockBaseIterableRequest).not.toHaveBeenCalled();
+    });
+
+    it('should not call updateUser when userUpdateObject only contains eventType', async () => {
+      const userUpdateData = {
+        eventType: 'userUpdate'
+      };
+
+      (localStorage.getItem as jest.Mock).mockImplementation((key) => {
+        if (key === SHARED_PREFS_USER_UPDATE_OBJECT_KEY) {
+          return JSON.stringify(userUpdateData);
+        }
+        if (key === SHARED_PREFS_EVENT_LIST_KEY) {
+          return JSON.stringify([]);
+        }
+        return null;
+      });
+
+      await unknownUserEventManager.syncEvents();
+
+      expect(mockBaseIterableRequest).not.toHaveBeenCalled();
+    });
+
+    it('should handle userUpdateObject with only email and userId (no dataFields)', async () => {
+      const userUpdateData = {
+        email: 'test@example.com',
+        userId: 'user123',
+        eventType: 'userUpdate'
+      };
+
+      (localStorage.getItem as jest.Mock).mockImplementation((key) => {
+        if (key === SHARED_PREFS_USER_UPDATE_OBJECT_KEY) {
+          return JSON.stringify(userUpdateData);
+        }
+        if (key === SHARED_PREFS_EVENT_LIST_KEY) {
+          return JSON.stringify([]);
+        }
+        return null;
+      });
+
+      await unknownUserEventManager.syncEvents();
+
+      // Should not call updateUser since all fields were stripped
+      expect(mockBaseIterableRequest).not.toHaveBeenCalled();
+    });
+
+    it('should process track events and user updates together', async () => {
+      const trackEvents = [
+        {
+          eventName: 'testEvent',
+          dataFields: { eventData: 'test' },
+          eventType: 'customEvent'
+        }
+      ];
+
+      const userUpdateData = {
+        firstName: 'John',
+        lastName: 'Doe',
+        eventType: 'userUpdate'
+      };
+
+      (localStorage.getItem as jest.Mock).mockImplementation((key) => {
+        if (key === SHARED_PREFS_USER_UPDATE_OBJECT_KEY) {
+          return JSON.stringify(userUpdateData);
+        }
+        if (key === SHARED_PREFS_EVENT_LIST_KEY) {
+          return JSON.stringify(trackEvents);
+        }
+        return null;
+      });
+
+      await unknownUserEventManager.syncEvents();
+
+      // Should call track for the event
+      expect(mockBaseIterableRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: 'POST',
+          url: expect.stringContaining('/events/track'),
+          data: expect.objectContaining({
+            eventName: 'testEvent',
+            dataFields: { eventData: 'test' }
+          })
+        })
+      );
+
+             // Should call updateUser for the user data
+       expect(mockBaseIterableRequest).toHaveBeenCalledWith(
+         expect.objectContaining({
+           method: 'POST',
+           url: expect.stringContaining('/users/update'),
+           data: expect.objectContaining({
+             dataFields: {
+               firstName: 'John',
+               lastName: 'Doe'
+             }
+           })
+         })
+       );
+     });
+
+     it('should replay profile events when criteria are met and createUnknownUser is called', async () => {
+       const userUpdateData = {
+         firstName: 'John',
+         lastName: 'Doe',
+         age: 30,
+         eventType: 'userUpdate'
+       };
+
+       // Mock localStorage to simulate stored user update data
+       (localStorage.getItem as jest.Mock).mockImplementation((key) => {
+         if (key === SHARED_PREFS_USER_UPDATE_OBJECT_KEY) {
+           return JSON.stringify(userUpdateData);
+         }
+         if (key === SHARED_PREFS_UNKNOWN_SESSIONS) {
+           return JSON.stringify({
+             itbl_unknown_sessions: {
+               number_of_sessions: 1,
+               first_session: 123456789,
+               last_session: 123456789
+             }
+           });
+         }
+         if (key === SHARED_PREF_UNKNOWN_USAGE_TRACKED) {
+           return 'true';
+         }
+         if (key === SHARED_PREF_CONSENT_TIMESTAMP) {
+           return '1234567890'; // Mock consent timestamp
+         }
+         if (key === SHARED_PREFS_EVENT_LIST_KEY) {
+           return JSON.stringify([]);
+         }
+         return null;
+       });
+
+       // Mock window object for the test
+       global.window = Object.create({
+         location: { hostname: 'test.example.com' },
+         navigator: { userAgent: 'test-user-agent' }
+       });
+
+       // Mock successful session creation response
+       mockBaseIterableRequest.mockResolvedValue({
+         status: 200,
+         data: { success: true }
+       } as any);
+
+       // Call createUnknownUser to simulate criteria being met
+       await unknownUserEventManager.createUnknownUser('123');
+
+       // Verify that the session endpoint was called
+       expect(mockBaseIterableRequest).toHaveBeenCalledWith(
+         expect.objectContaining({
+           method: 'POST',
+           url: expect.stringContaining('/unknownuser/events/session'),
+           data: expect.objectContaining({
+             user: expect.objectContaining({
+               dataFields: {
+                 firstName: 'John',
+                 lastName: 'Doe',
+                 age: 30
+               }
+             })
+           })
+         })
+       );
+
+       // Verify that the /users/update endpoint was also called during syncEvents
+       expect(mockBaseIterableRequest).toHaveBeenCalledWith(
+         expect.objectContaining({
+           method: 'POST',
+           url: expect.stringContaining('/users/update'),
+           data: expect.objectContaining({
+             dataFields: {
+               firstName: 'John',
+               lastName: 'Doe',
+               age: 30
+             },
+             preferUserId: true
+           })
+         })
+       );
+
+       // Verify that the user update data was removed after syncing
+       expect(localStorage.removeItem).toHaveBeenCalledWith(SHARED_PREFS_USER_UPDATE_OBJECT_KEY);
+     });
+   });
 });


### PR DESCRIPTION
## JIRA Ticket(s) if any

* [MOB-11918](https://iterable.atlassian.net/browse/MOB-11918)

## Description

User profile updates weren't being properly called on `syncEvents`. Also fixed an issue where the profile update triggering criteria completion wouldn't be synced so fixed that as well. 

## Test Steps

[MOB-11918]: https://iterable.atlassian.net/browse/MOB-11918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ