### PR TITLE
FIX - Update publish workflow to use NPM Trusted Publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,9 @@ jobs:
   publish:
     environment: npm
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Use Node.js 18.12.0
@@ -15,11 +18,10 @@ jobs:
         with:
           node-version: '18.12.0'
           cache: 'yarn'
+          registry-url: 'https://registry.npmjs.org'
       - run: yarn install --frozen-lockfile
       - run: yarn test
       - run: yarn build
       - run: yarn build:node
-      - uses: JS-DevTools/npm-publish@19c28f1ef146469e409470805ea4279d47c3d35c # v3.1.1
-        with:
-          token: ${{ secrets.NPM_TOKEN }}
-          strategy: all
+      - name: Publish to npm
+        run: npm publish --provenance


### PR DESCRIPTION
Deprecates the token based authentication with NPM and set up Trusted Publishing approach.