### PR TITLE
Remove lodash and uuid dependencies to reduce bundle size

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,10 +39,8 @@
     "buffer": "^6.0.3",
     "copy-webpack-plugin": "^11.0.0",
     "idb-keyval": "^6.2.0",
-    "lodash": "^4.17.21",
     "qs": "^6.12.3",
     "throttle-debounce": "^3.0.1",
-    "uuid": "^9.0.0",
     "yup": "^0.32.9"
   },
   "scripts": {
@@ -74,7 +72,6 @@
     "@types/jest": "^28.1.1",
     "@types/node": "^12.12.6",
     "@types/throttle-debounce": "^2.1.0",
-    "@types/uuid": "^9.0.8",
     "@typescript-eslint/eslint-plugin": "^5.38.1",
     "@typescript-eslint/parser": "^5.38.1",
     "@webpack-cli/serve": "^1.6.0",

--- a/src/embedded/embeddedSessionManager.ts
+++ b/src/embedded/embeddedSessionManager.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-param-reassign */
 /* eslint-disable class-methods-use-this */
-import { v4 as uuidv4 } from 'uuid';
+import { generateUUID } from '../utils/generateUUID';
 import { trackEmbeddedSession } from '../events/embedded/events';
 import { IterableEmbeddedSessionRequestPayload } from '..';
 
@@ -14,7 +14,7 @@ class EmbeddedSession {
   constructor(start?: Date, end?: Date) {
     this.start = start;
     this.end = end;
-    this.id = uuidv4();
+    this.id = generateUUID();
   }
 }
 

--- a/src/inapp/inapp.ts
+++ b/src/inapp/inapp.ts
@@ -1,7 +1,6 @@
 /* eslint-disable consistent-return */
 /* eslint-disable no-param-reassign */
 /* eslint-disable no-redeclare */
-import set from 'lodash/set';
 import { throttle } from 'throttle-debounce';
 import {
   ABSOLUTE_DISMISS_BUTTON_ID,
@@ -685,7 +684,13 @@ export function getInAppMessages(
     const withIframes = messages?.map((message) => {
       const html = message.content?.html;
       return html
-        ? set(message, 'content.html', wrapWithIFrame(html as string))
+        ? {
+            ...message,
+            content: {
+              ...message.content,
+              html: wrapWithIFrame(html as string)
+            }
+          }
         : message;
     });
     return {

--- a/src/unknownUserTracking/unknownUserEventManager.ts
+++ b/src/unknownUserTracking/unknownUserEventManager.ts
@@ -1,5 +1,5 @@
 /* eslint-disable class-methods-use-this */
-import { v4 as uuidv4 } from 'uuid';
+import { generateUUID } from '../utils/generateUUID';
 import {
   UpdateCartRequestParams,
   TrackPurchaseRequestParams,
@@ -263,7 +263,7 @@ export class UnknownUserEventManager {
 
     delete dataFields[SHARED_PREFS_EVENT_TYPE];
 
-    const userId = uuidv4();
+    const userId = generateUUID();
 
     if (userData) {
       const userSessionInfo = JSON.parse(userData);

--- a/src/utils/generateUUID.ts
+++ b/src/utils/generateUUID.ts
@@ -1,0 +1,12 @@
+/* eslint-disable no-bitwise */
+export function generateUUID(): string {
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
+  // Fallback for environments without crypto.randomUUID (e.g. Node 18)
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1741,11 +1741,6 @@
   resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.5.tgz#cb6e2a691b70cb177c6e3ae9c1d2e8b2ea8cd304"
   integrity sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==
 
-"@types/uuid@^9.0.8":
-  version "9.0.8"
-  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-9.0.8.tgz#7545ba4fc3c003d6c756f651f3bf163d8f0f29ba"
-  integrity sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==
-
 "@types/ws@8.5.4":
   version "8.5.4"
   resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.5.4.tgz#bb10e36116d6e570dd943735f86c933c1587b8a5"
@@ -7630,11 +7625,6 @@ uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
-
-uuid@^9.0.0:
-  version "9.0.1"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
-  integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
 
 v8-to-istanbul@^9.0.1:
   version "9.3.0"


### PR DESCRIPTION
Replace lodash/set with a simple object spread (single usage in inapp.ts) and replace uuid with native crypto.randomUUID() plus a fallback, removing ~73KB of unnecessary dependency weight. Fixes #442.

https://claude.ai/code/session_01EkgzU53JWSx3YHoupSiixd

## JIRA Ticket(s) if any

* [MOB-XXXX](https://iterable.atlassian.net/browse/MOB-XXXX)

## Description

## Test Steps