### PR TITLE
fix: move dev-only deps to devDependencies and make customPayload opt…

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,9 +35,7 @@
     "@pabra/sortby": "^1.0.1",
     "@types/ws": "8.5.4",
     "axios": "1.14.0",
-    "axios-mock-adapter": "^1.22.0",
     "buffer": "^6.0.3",
-    "copy-webpack-plugin": "^11.0.0",
     "idb-keyval": "^6.2.0",
     "lodash": "^4.17.21",
     "qs": "^6.12.3",
@@ -61,6 +59,7 @@
     "clean": "find . -name \"node_modules\" -exec rm -rf '{}' +"
   },
   "devDependencies": {
+    "axios-mock-adapter": "^1.22.0",
     "@babel/cli": "^7.5.5",
     "@babel/core": "^7.5.5",
     "@babel/plugin-proposal-class-properties": "^7.5.5",
@@ -81,6 +80,7 @@
     "babel-loader": "^9.1.3",
     "babel-plugin-module-resolver": "^5.0.0",
     "concurrently": "^6.3.0",
+    "copy-webpack-plugin": "^11.0.0",
     "css-loader": "^6.8.1",
     "dotenv": "^10.0.0",
     "eslint": "^8.2.0",

--- a/src/inapp/types.ts
+++ b/src/inapp/types.ts
@@ -50,7 +50,7 @@ export interface InAppMessage {
     };
     webInAppDisplaySettings: WebInAppDisplaySettings;
   };
-  customPayload: Record<string, any>;
+  customPayload?: Record<string, any>;
   trigger: { type: string };
   saveToInbox: boolean;
   inboxMetadata: {


### PR DESCRIPTION
…ional

Move copy-webpack-plugin and axios-mock-adapter from dependencies to devDependencies since they are only used in webpack dev config and test files respectively. This prevents consumers from installing unnecessary packages, including the vulnerable serialize-javascript transitive dep.

Also make InAppMessage.customPayload optional to match runtime behavior where the API may return undefined when no custom payload is configured.

Fixes #528, Fixes #538

https://claude.ai/code/session_011XYfVrCRu4H8y24ZEpoboX

## JIRA Ticket(s) if any

* [MOB-XXXX](https://iterable.atlassian.net/browse/MOB-XXXX)

## Description

## Test Steps