### PR TITLE
Add ESM package exports with conditional imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,16 @@
     "typescript"
   ],
   "main": "./index.node.js",
+  "module": "./dist/esm/index.js",
   "browser": "./index.js",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/esm/index.js",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
   "unpkg": "./index.js",
   "files": [
     "index.js",
@@ -29,7 +37,8 @@
     "index.node.js",
     "dist/*",
     "package.json",
-    "README.md"
+    "README.md",
+    "dist/esm/*"
   ],
   "dependencies": {
     "@pabra/sortby": "^1.0.1",
@@ -57,8 +66,9 @@
     "lint": "eslint src --ignore-pattern '*.test.*' --ignore-pattern '*.spec.*' --ext '.ts,.tsx'",
     "typecheck": "ttsc --noEmit true --emitDeclarationOnly false",
     "check-deps": "madge --extensions js,ts --circular dist",
-    "prepublishOnly": "yarn lint && yarn typecheck && yarn format && yarn build && yarn build:node",
-    "clean": "find . -name \"node_modules\" -exec rm -rf '{}' +"
+    "prepublishOnly": "yarn lint && yarn typecheck && yarn format && yarn build && yarn build:node && yarn build:esm",
+    "clean": "find . -name \"node_modules\" -exec rm -rf '{}' +",
+    "build:esm": "ttsc --project tsconfig.esm.json && babel src --out-dir ./dist/esm --extensions \".ts,.tsx\""
   },
   "devDependencies": {
     "@babel/cli": "^7.5.5",

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "outDir": "./dist/esm",
+    "declaration": false
+  }
+}


### PR DESCRIPTION
## Summary
- Add ESM build via tsconfig.esm.json
- Add conditional exports in package.json for import/require
- Add module field pointing to ESM entry

## Test plan
- [ ] ESM build produces valid ES modules
- [ ] Existing require() still resolves correctly
- [ ] import {} from '@iterable/web-sdk' resolves to ESM

🤖 Generated with [Claude Code](https://claude.com/claude-code)