### PR TITLE
Add ESM build output for better tree-shaking support

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "install:all": "yarn && cd example && yarn && cd ../react-example && yarn",
     "start:all": "concurrently \"yarn start\" \"cd example && yarn start\" -n 'module,website' -k",
     "start:all:react": "concurrently \"yarn start\" \"cd react-example && yarn start\" -n 'module,website' -k",
-    "build": "ttsc && babel src --out-dir ./dist --extensions '.ts,.tsx' && webpack",
+    "build": "ttsc && babel src --out-dir ./dist --extensions \".ts,.tsx\" && webpack && yarn build:esm",
     "build:node": "yarn build --config webpack.node.config.js",
     "test": "jest --config jest.config.js --coverage",
     "format": "prettier --write \"src/**/*.{ts,tsx}\" \"src/**/*.{js}\" \"example/src/**/*.{ts,tsx}\" \"example/src/**/*.{js}\" \"react-example/src/**/*.{ts,tsx}\" \"react-example/src/**/*.{js}\" --no-error-on-unmatched-pattern",
@@ -58,7 +58,8 @@
     "typecheck": "ttsc --noEmit true --emitDeclarationOnly false",
     "check-deps": "madge --extensions js,ts --circular dist",
     "prepublishOnly": "yarn lint && yarn typecheck && yarn format && yarn build && yarn build:node",
-    "clean": "find . -name \"node_modules\" -exec rm -rf '{}' +"
+    "clean": "find . -name \"node_modules\" -exec rm -rf '{}' +",
+    "build:esm": "ttsc -p tsconfig.esm.json"
   },
   "devDependencies": {
     "@babel/cli": "^7.5.5",
@@ -122,5 +123,21 @@
       "prettier --write",
       "eslint"
     ]
+  },
+  "module": "./dist/esm/index.js",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./index.node.js"
+      },
+      "browser": "./index.js",
+      "default": "./index.node.js"
+    },
+    "./package.json": "./package.json"
   }
 }

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,0 +1,25 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": false,
+    "outDir": "./dist/esm",
+    "sourceMap": true
+  },
+  "include": [
+    "src/**/*",
+    "src/iterable_logo.d.ts",
+    "src/**/*.ts",
+    "src/**/*.tsx"
+  ],
+  "exclude": [
+    "node_modules",
+    "**/__tests__/*",
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "example"
+  ]
+}


### PR DESCRIPTION
## Summary
- Add ESM build output alongside existing AMD/CJS build via a new `tsconfig.esm.json`
- Add `module` field and conditional `exports` in package.json
- Enables tree-shaking for consumers using modern bundlers

## Test plan
- [x] ESM build compiles successfully
- [ ] Existing CJS/AMD build still works
- [ ] Package exports resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)