### PR TITLE
Add option to control URL open target (same tab vs new tab)

### DIFF
--- a/src/utils/IterableActionRunner.ts
+++ b/src/utils/IterableActionRunner.ts
@@ -36,7 +36,8 @@ class IterableActionRunnerImpl {
       }
     }
 
-    window.open(uri, '_blank');
+    const target = IterableConfig.openLinksInNewTab ? '_blank' : '_self';
+    window.open(uri, target);
 
     return true;
   }

--- a/src/utils/IterableConfig.ts
+++ b/src/utils/IterableConfig.ts
@@ -4,4 +4,12 @@ export class IterableConfig {
   public static urlHandler: IterableUrlHandler | null = null;
 
   public static customActionHandler: IterableCustomActionHandler | null = null;
+
+  /**
+   * Controls whether URLs opened by the SDK (e.g. from embedded message
+   * buttons) are opened in a new tab (`_blank`) or in the same tab (`_self`).
+   *
+   * Defaults to `true` (new tab / `_blank`) for backward compatibility.
+   */
+  public static openLinksInNewTab = true;
 }


### PR DESCRIPTION
## Summary
- Add configurable `openLinksInNewTab` static property to `IterableConfig` that controls whether URLs are opened in a new tab (`_blank`) or the same tab (`_self`)
- Default remains `true` (`_blank`) for backward compatibility

## Test plan
- [ ] Default behavior opens in new tab (backward compatible)
- [ ] Setting `IterableConfig.openLinksInNewTab = false` opens in same tab (`_self`)
- [ ] TypeScript types are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)