### PR TITLE
Make InAppMessage.customPayload optional in type definition

### DIFF
--- a/src/inapp/types.ts
+++ b/src/inapp/types.ts
@@ -50,7 +50,7 @@ export interface InAppMessage {
     };
     webInAppDisplaySettings: WebInAppDisplaySettings;
   };
-  customPayload: Record<string, any>;
+  customPayload?: Record<string, any>;
   trigger: { type: string };
   saveToInbox: boolean;
   inboxMetadata: {


### PR DESCRIPTION
## Summary
- Make customPayload property optional in InAppMessage interface
- Accurately reflects runtime behavior where customPayload can be undefined

## Test plan
- [ ] TypeScript compilation passes
- [ ] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)