### PR TITLE
Add deleteAction field to trackInAppConsume for inAppDelete events

### DIFF
--- a/src/events/inapp/events.schema.ts
+++ b/src/events/inapp/events.schema.ts
@@ -9,6 +9,7 @@ export const eventRequestSchema = object().shape({
     location: string()
   }),
   closeAction: string(),
+  deleteAction: string(),
   deviceInfo: object()
     .shape({
       deviceId: string().required(),

--- a/src/events/inapp/types.ts
+++ b/src/events/inapp/types.ts
@@ -15,6 +15,7 @@ export interface InAppEventRequestParams {
     location?: string;
   };
   closeAction?: string;
+  deleteAction?: string;
   deviceInfo: {
     appPackageName: string; // customer-defined name
   };


### PR DESCRIPTION
## Summary
- Add optional `deleteAction` field to `InAppEventRequestParams` type
- Update event schema to include `deleteAction` validation
- Enables generation of `inAppDelete` events via `trackInAppConsume`

## Test plan
- [ ] Verify trackInAppConsume accepts deleteAction parameter
- [ ] Verify deleteAction is sent in the API request body
- [ ] TypeScript compilation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)