### PR TITLE
Add setGenerateJWT method to update JWT generator after initialization

### DIFF
--- a/src/authorization/authorization.ts
+++ b/src/authorization/authorization.ts
@@ -1192,6 +1192,21 @@ export function initializeWithConfig(initializeParams: InitializeParams) {
     : initialize(authToken);
 }
 
+/**
+ * Updates the JWT generator function used by the SDK.
+ *
+ * This is useful when the outer context that the `generateJWT` callback
+ * closes over changes after `initialize()` has already been called
+ * (e.g., when an upstream auth token is refreshed).
+ *
+ * @param newGenerateJWT - A function that returns a Promise resolving to a JWT string.
+ */
+export function setGenerateJWT(
+  newGenerateJWT: (payload: GenerateJWTPayload) => Promise<string>
+) {
+  generateJWTGlobal = newGenerateJWT;
+}
+
 export function setTypeOfAuthForTestingOnly(authType: TypeOfAuth) {
   if (!authType) {
     setTypeOfAuth(null);


### PR DESCRIPTION
## Summary
- Add setGenerateJWT method to allow updating the JWT generator function
- Enables re-initialization of JWT generation when outer tokens change

## Test plan
- [ ] Initialize SDK with JWT, update generateJWT, verify new function is used
- [ ] Verify backward compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)