### PR TITLE
Upgrade axios@1.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@pabra/sortby": "^1.0.1",
     "@types/ws": "8.5.4",
-    "axios": "1.14.0",
+    "axios": "1.16.0",
     "axios-mock-adapter": "^1.22.0",
     "buffer": "^6.0.3",
     "copy-webpack-plugin": "^11.0.0",
@@ -114,7 +114,7 @@
     }
   },
   "resolutions": {
-    "axios": "1.14.0"
+    "axios": "1.16.0"
   },
   "lint-staged": {
     "*.{ts,tsx,js}": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -2315,12 +2315,12 @@ axios-mock-adapter@^1.22.0:
     fast-deep-equal "^3.1.3"
     is-buffer "^2.0.5"
 
-axios@1.14.0:
-  version "1.14.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.14.0.tgz#7c29f4cf2ea91ef05018d5aa5399bf23ed3120eb"
-  integrity sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==
+axios@1.16.0:
+  version "1.16.0"
+  resolved "https://artifactory.squarespace.net/artifactory/api/npm/npm-all/axios/-/axios-1.16.0.tgz#f8e5dd931cef2a5f8c32216d5784eda2f8750eb7"
+  integrity sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==
   dependencies:
-    follow-redirects "^1.15.11"
+    follow-redirects "^1.16.0"
     form-data "^4.0.5"
     proxy-from-env "^2.1.0"
 
@@ -4028,10 +4028,10 @@ follow-redirects@^1.0.0:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.9.tgz#a604fa10e443bf98ca94228d9eebcc2e8a2c8ee1"
   integrity sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==
 
-follow-redirects@^1.15.11:
-  version "1.15.11"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.11.tgz#777d73d72a92f8ec4d2e410eb47352a56b8e8340"
-  integrity sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==
+follow-redirects@^1.16.0:
+  version "1.16.0"
+  resolved "https://artifactory.squarespace.net/artifactory/api/npm/npm-all/follow-redirects/-/follow-redirects-1.16.0.tgz#28474a159d3b9d11ef62050a14ed60e4df6d61bc"
+  integrity sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==
 
 for-each@^0.3.3:
   version "0.3.3"


### PR DESCRIPTION
## Description
We're trying to adopt iterable-web-sdk at my company, Squarespace, however this will not pass our Vulnerability Scan step because [this CVE](https://www.cve.org/CVERecord?id=CVE-2025-62718).

```
New Vulnerable Dependency: axios
---
  Vulnerability: Axios: Incomplete Fix for CVE-2025-62718 — NO_PROXY Protection Bypassed via RFC 1122 Loopback Subnet (127.0.0.0/8) in Axios 1.15.0
  Severity: high
  Advisory: https://github.com/advisories/GHSA-pmwg-cvhr-8vh7
  Vulnerability in Versions: >=1.0.0 <1.15.1
  Version(s) in lock file: 1.13.4, 1.14.0, 1.7.4, 1.7.7, 1.8.4
  ---
  Vulnerability: Axios: Prototype Pollution Gadgets - Response Tampering, Data Exfiltration, and Request Hijacking
  Severity: high
  Advisory: https://github.com/advisories/GHSA-pf86-5x62-jrwf
  Vulnerability in Versions: >=1.0.0 <1.15.1
  Version(s) in lock file: 1.13.4, 1.14.0, 1.7.4, 1.7.7, 1.8.4
  ---
  Vulnerability: Axios: Header Injection via Prototype Pollution
  Severity: high
  Advisory: https://github.com/advisories/GHSA-6chq-wfr3-2hj9
  Vulnerability in Versions: >=1.0.0 <1.15.1
  Version(s) in lock file: 1.13.4, 1.14.0, 1.7.4, 1.7.7, 1.8.4
  ---
  Vulnerability: Axios has prototype pollution read-side gadgets in HTTP adapter that allow credential injection and request hijacking
  Severity: high
  Advisory: https://github.com/advisories/GHSA-q8qp-cvcw-x6jj
  Vulnerability in Versions: >=1.0.0 <1.15.2
  Version(s) in lock file: 1.13.4, 1.14.0, 1.7.4, 1.7.7, 1.8.4
  ---
  ```


## Test Steps
Ran the test