### PR TITLE
[SDK-646] Bump Web SDK version to v2.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@iterable/web-sdk",
   "description": "Iterable SDK for JavaScript and Node.",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "homepage": "https://iterable.com/",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# 📝 Summary
Bump the Web SDK package version from 2.2.2 to 2.3.0 for the next release.

###### 🎟️ Jira Ticket: [SDK-646](https://iterable.atlassian.net/browse/SDK-646)

## 📖 Description
Version bump only. Updates `version` in `package.json` from `2.2.2` to `2.3.0` on the `release/v2.3.0` branch, cut from `main`. No source or behavior changes.

## 🧪 How to test?
- Confirm `package.json` reads `"version": "2.3.0"`.
- CI (typecheck + jest) passes; ran locally via the pre-push hook (258/258 tests passing).

## 📹 Loom recording if applicable
> N/A

#### 🐞 Github Issues solved
> N/A

#### 📚 Docs PR if applicable
https://github.com/Iterable/iterable-docs/pull/1562

[SDK-646]: https://iterable.atlassian.net/browse/SDK-646?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ