### PR TITLE
SDK-563 pass configurable preferUserId through tryUser to setUserID/setEmail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Fixes
+- Pass `preferUserId` through `setUserID` and JWT `setEmail` into the identify-time `/users/update` call (`tryUser`), so callers can opt out of user creation when identifying a user (SDK-563).
 
 ## [2.2.2]
 ### Fixes

--- a/src/authorization/authorization.test.ts
+++ b/src/authorization/authorization.test.ts
@@ -378,6 +378,11 @@ describe('API Key Interceptors', () => {
 });
 
 describe('User Identification', () => {
+  const getUsersUpdatePayloads = () =>
+    mockRequest.history.post
+      .filter((e: any) => !!e.url?.match(/users\/update/gim))
+      .map((e: any) => JSON.parse(e.data));
+
   beforeEach(() => {
     setTypeOfAuthForTestingOnly('userID');
 
@@ -807,6 +812,26 @@ describe('User Identification', () => {
         expect(response.config.params.email).toBeUndefined();
         expect(response.config.params.userId).toBe('999');
       });
+
+      it('defaults preferUserId to true on the identify-time users/update call', async () => {
+        mockRequest.onPost('/users/update').reply(200, {});
+        const { setUserID } = initialize('123');
+        await setUserID('999');
+
+        const payloads = getUsersUpdatePayloads();
+        expect(payloads.length).toBeGreaterThan(0);
+        expect(payloads[0].preferUserId).toBe(true);
+      });
+
+      it('passes preferUserId false through tryUser to users/update', async () => {
+        mockRequest.onPost('/users/update').reply(200, {});
+        const { setUserID } = initialize('123');
+        await setUserID('999', undefined, false);
+
+        const payloads = getUsersUpdatePayloads();
+        expect(payloads.length).toBeGreaterThan(0);
+        expect(payloads[0].preferUserId).toBe(false);
+      });
     });
   });
 
@@ -1011,6 +1036,32 @@ describe('User Identification', () => {
         expect(response.config.params.userId).toBeUndefined();
         expect(response.config.params.email).toBe('hello@gmail.com');
       });
+
+      it('defaults preferUserId to true on the identify-time users/update call', async () => {
+        mockRequest.resetHistory();
+        mockRequest.onPost('/users/update').reply(200, {});
+        const { setEmail } = initialize('123', () =>
+          Promise.resolve(MOCK_JWT_KEY)
+        );
+        await setEmail('hello@gmail.com');
+
+        const payloads = getUsersUpdatePayloads();
+        expect(payloads.length).toBeGreaterThan(0);
+        expect(payloads[0].preferUserId).toBe(true);
+      });
+
+      it('passes preferUserId false through tryUser to users/update', async () => {
+        mockRequest.resetHistory();
+        mockRequest.onPost('/users/update').reply(200, {});
+        const { setEmail } = initialize('123', () =>
+          Promise.resolve(MOCK_JWT_KEY)
+        );
+        await setEmail('hello@gmail.com', undefined, false);
+
+        const payloads = getUsersUpdatePayloads();
+        expect(payloads.length).toBeGreaterThan(0);
+        expect(payloads[0].preferUserId).toBe(false);
+      });
     });
 
     describe('setUserID', () => {
@@ -1185,6 +1236,30 @@ describe('User Identification', () => {
             ).length
           ).toBe(4);
         }
+      });
+
+      it('defaults preferUserId to true on the identify-time users/update call', async () => {
+        mockRequest.onPost('/users/update').reply(200, {});
+        const { setUserID } = initialize('123', () =>
+          Promise.resolve(MOCK_JWT_KEY)
+        );
+        await setUserID('999');
+
+        const payloads = getUsersUpdatePayloads();
+        expect(payloads.length).toBeGreaterThan(0);
+        expect(payloads[0].preferUserId).toBe(true);
+      });
+
+      it('passes preferUserId false through tryUser to users/update', async () => {
+        mockRequest.onPost('/users/update').reply(200, {});
+        const { setUserID } = initialize('123', () =>
+          Promise.resolve(MOCK_JWT_KEY)
+        );
+        await setUserID('999', undefined, false);
+
+        const payloads = getUsersUpdatePayloads();
+        expect(payloads.length).toBeGreaterThan(0);
+        expect(payloads[0].preferUserId).toBe(false);
       });
     });
 

--- a/src/authorization/authorization.ts
+++ b/src/authorization/authorization.ts
@@ -52,11 +52,13 @@ export interface GenerateJWTPayload {
 export interface WithJWT {
   setEmail: (
     email: string,
-    identityResolution?: IdentityResolution
+    identityResolution?: IdentityResolution,
+    preferUserId?: boolean
   ) => Promise<string>;
   setUserID: (
     userId: string,
-    identityResolution?: IdentityResolution
+    identityResolution?: IdentityResolution,
+    preferUserId?: boolean
   ) => Promise<string>;
   logout: () => void;
   refreshJwtToken: (authTypes: string) => Promise<string>;
@@ -72,7 +74,8 @@ export interface WithoutJWT {
   ) => Promise<string>;
   setUserID: (
     userId: string,
-    identityResolution?: IdentityResolution
+    identityResolution?: IdentityResolution,
+    preferUserId?: boolean
   ) => Promise<string>;
   logout: () => void;
   setNewAuthToken: (newToken?: string) => void;
@@ -464,12 +467,12 @@ export function initialize(
 
   const handleTokenExpiration = createTokenExpirationTimer();
 
-  const tryUser = () => {
+  const tryUser = (preferUserId?: boolean) => {
     let createUserAttempts = 0;
 
     return async function tryUserNTimes(): Promise<any> {
       try {
-        return await updateUser({});
+        return await updateUser({ preferUserId });
       } catch (e) {
         if (createUserAttempts < RETRY_USER_ATTEMPTS) {
           createUserAttempts += 1;
@@ -587,7 +590,8 @@ export function initialize(
       },
       setUserID: async (
         userId: string,
-        identityResolution?: IdentityResolution
+        identityResolution?: IdentityResolution,
+        preferUserId?: boolean
       ) => {
         clearMessages();
         try {
@@ -596,7 +600,7 @@ export function initialize(
 
           // Initialize user authentication first, then create user profile
           initializeUserId(userId);
-          await tryUser()();
+          await tryUser(preferUserId)();
 
           const result = await tryMergeUser(userId, false, merge);
           if (result.success) {
@@ -963,7 +967,8 @@ export function initialize(
     },
     setEmail: async (
       email: string,
-      identityResolution?: IdentityResolution
+      identityResolution?: IdentityResolution,
+      preferUserId?: boolean
     ) => {
       /* clear previous user */
       clearMessages();
@@ -978,7 +983,7 @@ export function initialize(
               initializeEmailUser(email);
 
               // Create user profile first before attempting merge
-              await tryUser()();
+              await tryUser(preferUserId)();
 
               const result = await tryMergeUser(email, true, merge);
               if (result.success) {
@@ -1014,7 +1019,8 @@ export function initialize(
     },
     setUserID: async (
       userId: string,
-      identityResolution?: IdentityResolution
+      identityResolution?: IdentityResolution,
+      preferUserId?: boolean
     ) => {
       clearMessages();
       try {
@@ -1028,7 +1034,7 @@ export function initialize(
               initializeUserId(userId);
 
               // Create user profile after authentication is set up
-              await tryUser()();
+              await tryUser(preferUserId)();
 
               const result = await tryMergeUser(userId, false, merge);
               if (result.success) {


### PR DESCRIPTION
# 📝 Summary
Pass `preferUserId` through `tryUser` so `setUserID` / JWT `setEmail` can opt out of identify-time user creation (SDK-563 pt2).

###### 🎟️ Jira Ticket: [SDK-563](https://iterable.atlassian.net/browse/SDK-563)

## 📖 Description
Follow-up to [#578](https://github.com/Iterable/iterable-web-sdk/pull/578) / 2.3.0.

That release made `preferUserId` configurable on `updateUser`, `updateCart`, and `trackPurchase`, but `setUserID` / JWT `setEmail` still called `tryUser()` → `updateUser({})`, which forced `preferUserId: true`. Care.com (email-based project) hit this on identify and got placeholder / duplicate profiles.

This PR:
- Threads an optional `preferUserId` arg through `setUserID` and JWT `setEmail` into `tryUser` → `updateUser({ preferUserId })`
- Keeps the existing default (`undefined` → `true`) so callers that omit it behave as before
- Adds authorization tests for default `true` and explicit `false` on non-JWT `setUserID`, JWT `setUserID`, and JWT `setEmail`
- Adds a CHANGELOG Unreleased entry

Usage Care validated:
```js
setUserID('user-123', undefined, false)
```

## 🧪 How to test?
1. `yarn jest --config jest.config.js src/authorization/authorization.test.ts -t preferUserId`
2. In a sample app (JWT or non-JWT), call `setUserID('test-id', undefined, false)` and confirm `/users/update` body has `preferUserId: false`
3. Call `setUserID('test-id')` with no third arg and confirm `/users/update` still sends `preferUserId: true`

## 🧾 Changelog
CHANGELOG Unreleased entry added for the `tryUser` handoff (SDK-563).

## 📹 Loom recording if applicable
N/A

#### 🐞 Github Issues solved
N/A

#### 📚 Docs PR if applicable
https://github.com/Iterable/iterable-docs/pull/1574 (`docs/sdk/august-release`)

[SDK-563]: https://iterable.atlassian.net/browse/SDK-563?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ