### PR TITLE
[SDK-563] Bump Web SDK version to v2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+
+## [2.3.1]
 ### Fixes
 - Pass `preferUserId` through `setUserID` and JWT `setEmail` into the identify-time `/users/update` call (`tryUser`), so callers can opt out of user creation when identifying a user (SDK-563).
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@iterable/web-sdk",
   "description": "Iterable SDK for JavaScript and Node.",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "homepage": "https://iterable.com/",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# 📝 Summary
Bump the Web SDK package version from 2.3.0 to 2.3.1 for the next release.

###### 🎟️ Jira Ticket: [SDK-563](https://iterable.atlassian.net/browse/SDK-563)

## 📖 Description
Version bump for release. Updates `version` in `package.json` from `2.3.0` to `2.3.1` on the `release/v2.3.1` branch, cut from `main`. Also promotes the Unreleased CHANGELOG entry for SDK-563 under `## [2.3.1]`. No source or behavior changes beyond what's already on `main`.

## 🧪 How to test?
- Confirm `package.json` reads `"version": "2.3.1"`.
- Confirm `CHANGELOG.md` has `## [2.3.1]` with the `preferUserId` / `tryUser` fix, and an empty `## [Unreleased]` section.
- CI (typecheck + jest) passes.

## 🧾 Changelog
CHANGELOG.md updated: Unreleased section moved under 2.3.1.

## 📹 Loom recording if applicable
> N/A

#### 🐞 Github Issues solved
> N/A

#### 📚 Docs PR if applicable
> Follow-up: release notes for Web 2.3.1 in iterable-docs if needed (2.3.0 docs already covered the earlier preferUserId work).

[SDK-563]: https://iterable.atlassian.net/browse/SDK-563?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ